### PR TITLE
#3 Add a /support command to enable users to quickly be directed to the Issue Tracker

### DIFF
--- a/cfg/config-sample.json
+++ b/cfg/config-sample.json
@@ -1,6 +1,6 @@
 {
     "botToken": "YOUR_BOT_TOKEN_HERE",
     "bibleApiUrl": "https://labs.bible.org/api/?type=json&passage=",
-    "version": "0.1.0"
+    "version": "0.1.1"
   }
   

--- a/js/commands/support.js
+++ b/js/commands/support.js
@@ -1,0 +1,20 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { EmbedBuilder } = require('discord.js');
+const { version } = require('../../cfg/config.json');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('support')
+        .setDescription('Get support and report issues'),
+    execute(interaction) {
+        const supportEmbed = new EmbedBuilder()
+            .setTitle('Need Support or Found a Bug?')
+            .setColor('#FF0000')
+            .setTimestamp()
+            .setDescription(`If you need support, found a bug, or want to make a feature request, please visit our [Issue Tracker](https://github.com/michaelpa-dev/Daily-Bible-Verse-Bot/issues) to report the issue or request.`)
+            .setFooter({ text: `Bot Version: ${version}` })
+            .setThumbnail(interaction.client.user.displayAvatarURL());
+
+        interaction.reply({ embeds: [supportEmbed], ephemeral: true });
+    },
+};

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ The Daily Bible Verse Bot is a Discord bot that provides users with daily Bible 
 - `/unsubscribe`: Unsubscribe from receiving daily Bible verses.
 - `/randomverse`: Get a random Bible verse via DM.
 - `/stats`: View bot statistics, including subscribed users and command usage.
+- `/support`: Get a link to the issue tracker for reporting issues and requesting support.
 
 ## Directory Structure
 
@@ -71,7 +72,8 @@ daily-bible-verse-bot/
 │ │ ├── subscribe.js
 │ │ ├── unsubscribe.js
 │ │ ├── randomverse.js
-│ │ └── stats.js
+│ │ ├── stats.js
+│ │ └── support.js
 │ ├── db/
 │ │ ├── subscribeDB.js
 │ │ └── statsDB.js


### PR DESCRIPTION
**Description:**
As a user of the bot, I find it difficult to quickly access the issue tracker for reporting bugs or requesting support. Currently, there's no direct way to get to the issue tracker from the bot's profile, and I think having a support command would make it more convenient for users like me.

**Solution:**
I've added a new `/support` command that, when used, replies with a message containing a link to the bot's GitHub issue tracker. This allows users to easily report bugs, request features, and get support by clicking on the provided link.

**Benefits:**
- Streamlines the process of accessing the GitHub issue tracker.
- Enhances user experience by providing a dedicated support command.
- Encourages more users to provide feedback and contribute to the bot's improvement.

**Test Steps:**
1. Run the bot in a test environment.
2. Use the `/support` command in a Discord server where the bot is present.
3. Verify that the bot replies with a message containing a link to the GitHub issue tracker.
4. Click on the provided link to ensure that it redirects to the correct GitHub issue tracker.
5. Confirm that the message includes the correct context and information about the purpose of the support command.
6. Test the command with different server members to ensure consistent behavior.
7. Review the code changes in the `support.js` file to ensure correctness.

**Screenshots (if applicable):**
![screenshot](https://github.com/michaelpa-dev/Daily-Bible-Verse-Bot/assets/67399202/8a0f4f26-b629-4829-bcf6-8144d58acaea)
