### PR TITLE
Implementation of /version slash command

### DIFF
--- a/js/commands/version.js
+++ b/js/commands/version.js
@@ -1,0 +1,35 @@
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
+const { addCommandExecution } = require("../db/statsDB");
+const { logger } = require("../logger");
+const { default: axios } = require("axios");
+
+const REPOSITORY_OWNER = "michaelpa-dev"
+const REPOSITORY_NAME = "Daily-Bible-Verse-Bot"
+
+module.exports = {
+    data: new SlashCommandBuilder()
+    .setName("version")
+    .setDescription("Get the current version of the bot"),
+
+    async execute(interaction) {
+        await addCommandExecution()
+        logger.info(`Slash command /version called by ${interaction.user.username}`);
+
+        try {
+            const response = await axios.get(`https://api.github.com/repos/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/releases/latest`)
+            const latestVersion = response.data.tag_name
+
+            const embed = new EmbedBuilder()
+            .setTitle("Daily Bible Verse Version")
+            .setColor("#FF0000")
+            .setTimestamp()
+            .setDescription(`The current version is: ${"`"}${latestVersion}${"`"}`)
+            .setThumbnail(interaction.client.user.displayAvatarURL())
+
+            await interaction.reply({ embeds: [embed], ephemeral: true })
+        } catch (exception) {
+            logger.error(exception)
+            await interaction.reply({ content: "An error occurred while getting the version of the bot.", ephemeral: true })
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ daily-bible-verse-bot/
 │ │ ├── unsubscribe.js
 │ │ ├── randomverse.js
 │ │ ├── stats.js
-│ │ └── support.js
+│ │ ├── support.js
 │ │ └── version.js
 │ ├── db/
 │ │ ├── subscribeDB.js

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,7 @@ The Daily Bible Verse Bot is a Discord bot that provides users with daily Bible 
 - `/randomverse`: Get a random Bible verse via DM.
 - `/stats`: View bot statistics, including subscribed users and command usage.
 - `/support`: Get a link to the issue tracker for reporting issues and requesting support.
+- `/version`: Get the bot current release version
 
 ## Directory Structure
 

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ daily-bible-verse-bot/
 │ │ ├── randomverse.js
 │ │ ├── stats.js
 │ │ └── support.js
+│ │ └── version.js
 │ ├── db/
 │ │ ├── subscribeDB.js
 │ │ └── statsDB.js


### PR DESCRIPTION
Added the slash command `/version` at: `js/commands/version.js`
The command makes a request to the github API and gets the latest release version. The `readme.md` is also updated with the changes