### PR TITLE
Polish and productionize Discord dev server bootstrap + ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 /logs/archive/applicationExit*
 /db/stats.json
 /db/subscribed_users.json
+.vscode

--- a/cfg/config-sample.json
+++ b/cfg/config-sample.json
@@ -1,6 +1,8 @@
 {
-    "botToken": "YOUR_BOT_TOKEN_HERE",
-    "bibleApiUrl": "https://labs.bible.org/api/?type=json&passage=",
-    "version": "0.1.1"
-  }
-  
+  "botToken": "YOUR_BOT_TOKEN_HERE",
+  "bibleApiUrl": "https://labs.bible.org/api/?type=json&passage=",
+  "translationApiUrl": "https://bible-api.com/",
+  "defaultTranslation": "web",
+  "logLevel": "debug",
+  "version": "0.2.0"
+}

--- a/docs/discord-dev-server.md
+++ b/docs/discord-dev-server.md
@@ -1,0 +1,161 @@
+# Discord Dev Server Specification
+
+This document defines the desired Discord development server layout and operating model for the Daily Bible Verse Bot.
+
+Target guild:
+- `1471943418002280451`
+
+## Categories and Channels
+
+### `📌 INFO` (read-only for most members)
+
+`#welcome`
+- Purpose: New member orientation, where to start, and working norms.
+- Do post: onboarding instructions and important links.
+- Do not post: feature debates or bug threads.
+
+`#rules-and-safety`
+- Purpose: Conduct, moderation policy, and safety updates.
+- Do post: policy updates and moderation references.
+- Do not post: general discussion.
+
+`#roadmap`
+- Purpose: Current priorities, milestones, and release goals.
+- Do post: roadmap updates and status summaries.
+- Do not post: unrelated implementation chatter.
+
+`#changelog`
+- Purpose: Release notes and shipped changes.
+- Do post: formatted release announcements.
+- Do not post: planning discussion.
+
+### `🛠️ DEVELOPMENT`
+
+`#dev-chat`
+- Purpose: Day-to-day engineering conversation.
+- Do post: implementation plans, blockers, progress.
+- Do not post: production incident logs.
+
+`#help-requests`
+- Purpose: Focused requests for help.
+- Do post: concrete coding or debugging asks.
+- Do not post: unrelated social chat.
+
+`#ideas-backlog`
+- Purpose: Capture and triage future ideas.
+- Do post: proposal drafts and rough concepts.
+- Do not post: finalized release notes.
+
+`#design-decisions`
+- Purpose: Architecture Decision Records (ADRs) and rationale.
+- Do post: context, decision, alternatives, consequences.
+- Do not post: unresolved brainstorming without conclusion.
+
+`#pr-reviews`
+- Purpose: PR links and review coordination.
+- Do post: review requests, approval status, follow-up tasks.
+- Do not post: unrelated bug triage.
+
+`#qa-testing`
+- Purpose: test plans, bug reports, and verification logs.
+- Do post: repro steps, expected/actual outcomes, environment notes.
+- Do not post: long roadmap debates.
+
+### `🤖 BOT OPS`
+
+`#bot-status`
+- Purpose: heartbeat and periodic bot health summaries.
+- Do post: status snapshots and uptime updates.
+- Do not post: general conversation.
+
+`#bot-logs`
+- Purpose: structured command/runtime error logs.
+- Do post: bot-generated logs only.
+- Do not post: human discussion. Humans are read-only.
+
+`#alerts` (optional)
+- Purpose: high-priority operational alerts.
+- Do post: incident notifications and mitigations.
+- Do not post: routine development updates.
+
+### `🔊 VOICE` (optional)
+
+`Dev Huddle`
+- Purpose: live collaboration, pairing, and standups.
+- Do post: N/A (voice channel).
+- Do not post: N/A.
+
+## Roles
+
+`Maintainer`
+- Scope: owner-delegated operational role for server bootstrap, release notes, and dev-server governance.
+- Notes: admin-like workflow role, but not full `Administrator`.
+
+`Reviewer`
+- Scope: code review and quality gate participation.
+
+`Tester`
+- Scope: QA execution, bug reporting, and verification.
+
+`Contributor`
+- Scope: implementation and development discussion.
+
+`Muted`
+- Scope: moderation/testing role that blocks message sending in non-mod channels.
+
+## Permission Model
+
+### High-level intent
+
+- `@everyone` can read `📌 INFO` but cannot post there.
+- Contributors can write in development channels.
+- Testers can write in `#qa-testing`.
+- `#bot-logs` is bot-write-only with humans read-only.
+- `Muted` denies sending messages in non-mod channels.
+- Use per-channel permission overwrites as primary control plane.
+
+### Permission matrix (summary)
+
+| Channel Group | @everyone | Contributor | Tester | Reviewer | Maintainer | Muted |
+|---|---|---|---|---|---|---|
+| `📌 INFO` | Read, no send | No send unless elevated | No send unless elevated | No send unless elevated | Send allowed | Deny send |
+| `🛠️ DEVELOPMENT` | Read, no send | Send allowed | Send allowed | Send allowed | Send allowed | Deny send |
+| `#qa-testing` | Read, no send | Send allowed | Send allowed | Send allowed | Send allowed | Deny send |
+| `#bot-status` | Read, no send | No send | No send | No send | Optional send | Deny send |
+| `#bot-logs` | Read, no send | No send | No send | No send | No send | Deny send |
+| `#alerts` | Read, no send | No send | No send | No send | Send allowed | Deny send |
+
+Operational notes:
+- Explicit bot member overwrites should allow sending in `#bot-logs`, `#bot-status`, and optionally `#alerts`.
+- Existing moderation channels (names/category containing `mod`) are excluded from automatic muted overwrite enforcement.
+
+## Admin Setup Checklist (Discord UI)
+
+1. Enable Community features if needed (`Server Settings -> Enable Community`).
+2. Configure Rules or Screening if you require acceptance flow.
+3. Confirm role hierarchy places `Maintainer` appropriately under owner control.
+4. Set channel topics/descriptions to match this spec.
+5. Pin onboarding templates in:
+   - `#welcome`
+   - `#qa-testing`
+   - `#design-decisions`
+6. Verify bot has required permissions in this guild:
+   - `View Channels`
+   - `Send Messages`
+   - `Manage Channels`
+   - `Manage Roles`
+   - `Manage Messages` (for pinning/updating template content)
+7. Run bootstrap commands:
+   - `/bootstrap-dev-server dry_run:true`
+   - `/bootstrap-dev-server apply:true`
+8. Re-run dry run to confirm idempotency and minimal/no diffs.
+
+## Contributor Runbook
+
+- Use `#help-requests` for implementation blockers.
+- Use `#ideas-backlog` for proposal intake.
+- Use `#design-decisions` for ADR-style decisions.
+- Use `#pr-reviews` for review requests.
+- Use `#qa-testing` for bug and verification workflow.
+- Use `/release-notes` (Maintainers only) to publish to `#changelog`.
+- Treat `#bot-logs` as an operational stream, not a discussion channel.

--- a/js/commands/bootstrapDevServer.js
+++ b/js/commands/bootstrapDevServer.js
@@ -1,0 +1,103 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { addCommandExecution } = require('../db/statsDB.js');
+const { TARGET_DEV_GUILD_ID } = require('../constants/devServerSpec.js');
+const { requireOwnerOrMaintainer } = require('../services/permissionUtils.js');
+const { bootstrapDevServer } = require('../services/bootstrapDevServer.js');
+const {
+  buildBootstrapSummaryMessage,
+  sendBotLogMessage,
+} = require('../services/botOps.js');
+
+function splitMessage(content, maxChunkLength = 1800) {
+  if (content.length <= maxChunkLength) {
+    return [content];
+  }
+
+  const lines = content.split('\n');
+  const chunks = [];
+  let current = '';
+
+  for (const line of lines) {
+    const next = current ? `${current}\n${line}` : line;
+    if (next.length > maxChunkLength) {
+      if (current) {
+        chunks.push(current);
+      }
+      current = line;
+    } else {
+      current = next;
+    }
+  }
+
+  if (current) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('bootstrap-dev-server')
+    .setDescription('Create/repair Discord dev server roles, channels, and permissions')
+    .addBooleanOption((option) =>
+      option
+        .setName('dry_run')
+        .setDescription('Preview changes without applying them (default: true)')
+    )
+    .addBooleanOption((option) =>
+      option
+        .setName('apply')
+        .setDescription('Apply the bootstrap changes (default: false)')
+    ),
+  async execute(interaction) {
+    await addCommandExecution();
+
+    if (!interaction.guildId || interaction.guildId !== TARGET_DEV_GUILD_ID) {
+      await interaction.reply({
+        content:
+          `This command is only allowed in the configured dev guild (${TARGET_DEV_GUILD_ID}).`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const authorized = await requireOwnerOrMaintainer(interaction);
+    if (!authorized) {
+      return;
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const applyOption = interaction.options.getBoolean('apply') === true;
+    const dryRunOption = interaction.options.getBoolean('dry_run');
+    const applyChanges = applyOption;
+    const mode = applyChanges ? 'apply' : (dryRunOption === false ? 'inspect' : 'dry-run');
+
+    const report = await bootstrapDevServer(interaction.guild, { applyChanges });
+    const summary = buildBootstrapSummaryMessage(mode, report);
+    const replyChunks = splitMessage(summary, 1800);
+
+    await interaction.editReply({ content: replyChunks[0] });
+    for (let i = 1; i < replyChunks.length; i += 1) {
+      await interaction.followUp({ content: replyChunks[i], ephemeral: true });
+    }
+
+    const logChunks = splitMessage(summary, 1800);
+    let sentToBotLogs = false;
+    for (const chunk of logChunks) {
+      const sent = await sendBotLogMessage(interaction.client, interaction.guildId, {
+        content: chunk,
+      });
+      sentToBotLogs = sentToBotLogs || sent;
+    }
+
+    if (!sentToBotLogs) {
+      await interaction.followUp({
+        content:
+          'Summary could not be posted to #bot-logs because that channel was not found.',
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/js/commands/health.js
+++ b/js/commands/health.js
@@ -1,0 +1,16 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { addCommandExecution } = require('../db/statsDB.js');
+const { buildHealthEmbed } = require('../services/botOps.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('health')
+    .setDescription('Show bot runtime health information'),
+  async execute(interaction) {
+    await addCommandExecution();
+    await interaction.reply({
+      embeds: [buildHealthEmbed(interaction.client)],
+      ephemeral: true,
+    });
+  },
+};

--- a/js/commands/randomVerse.js
+++ b/js/commands/randomVerse.js
@@ -1,33 +1,73 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
-const { EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const sendDailyVerse = require('../verseSender');
 const { logger } = require('../logger.js');
 const { addCommandExecution } = require('../db/statsDB.js');
+const { getUserPreferences } = require('../db/subscribeDB.js');
+const {
+  DEFAULT_TRANSLATION,
+  getTranslationLabel,
+  normalizeTranslationCode,
+  toDiscordChoices,
+} = require('../constants/translations.js');
+const { logCommandError } = require('../services/botOps.js');
 
+const translationChoices = toDiscordChoices().slice(0, 25);
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName('randomverse')
-        .setDescription('Get a random bible verse via DM'),
-    async execute(interaction) {
-        await addCommandExecution();
-        logger.info(`Slash command /randomverse called by ${interaction.user.username}`);
-        const user = interaction.user; // Fetch the user to ensure accurate information
+  data: new SlashCommandBuilder()
+    .setName('randomverse')
+    .setDescription('Get a random Bible verse via DM')
+    .addStringOption((option) => {
+      option
+        .setName('translation')
+        .setDescription('Optional translation override for this request');
+      for (const choice of translationChoices) {
+        option.addChoices(choice);
+      }
+      return option;
+    }),
+  async execute(interaction) {
+    await addCommandExecution();
+    logger.info(`Slash command /randomverse called by ${interaction.user.username}`);
 
-        try {
-            const embed = new EmbedBuilder()
-            .setTitle('A random Bible verse has been sent to your DMs!')
-            .setColor('#FF0000')
-            .setTimestamp()
-            .setDescription('You will receive a random Bible verse in your DMs.')
-            .setFooter({ text: 'You can subscribe at any time by using the /subscribe command.'})
-            .setThumbnail(interaction.client.user.displayAvatarURL())
-            await interaction.reply({ embeds: [embed], ephemeral: true });      
+    try {
+      const requestedTranslation = interaction.options.getString('translation');
+      const preferences = await getUserPreferences(interaction.user.id);
+      const selectedTranslation = normalizeTranslationCode(
+        requestedTranslation || preferences?.translation || DEFAULT_TRANSLATION
+      );
+      const translationLabel = getTranslationLabel(selectedTranslation);
 
-            await sendDailyVerse(interaction.client, user, 'random');
-        } catch (error) {
-            logger.error(error);
-            await interaction.reply({ content: 'An error occurred while sending the random Bible verse.', ephemeral: true });
-        }
+      const embed = new EmbedBuilder()
+        .setTitle('A random Bible verse has been sent to your DMs')
+        .setColor('#0099FF')
+        .setTimestamp()
+        .setDescription(`Translation: ${translationLabel}.`)
+        .setFooter({
+          text: 'Use /settranslation to change your saved preference.',
+        })
+        .setThumbnail(interaction.client.user.displayAvatarURL());
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+
+      const didSend = await sendDailyVerse(interaction.client, interaction.user.id, 'random', {
+        translation: selectedTranslation,
+      });
+
+      if (!didSend) {
+        await interaction.followUp({
+          content: 'I could not send a verse to your DMs. Please check your DM privacy settings.',
+          ephemeral: true,
+        });
+      }
+    } catch (error) {
+      logger.error(error);
+      await logCommandError(interaction, error, 'Random verse command failed');
+      const message = 'An error occurred while sending the random Bible verse.';
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ content: message, ephemeral: true });
+      } else {
+        await interaction.reply({ content: message, ephemeral: true });
+      }
     }
+  },
 };

--- a/js/commands/releaseNotes.js
+++ b/js/commands/releaseNotes.js
@@ -1,0 +1,66 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { addCommandExecution } = require('../db/statsDB.js');
+const { requireOwnerOrMaintainer } = require('../services/permissionUtils.js');
+const {
+  getChangelogChannel,
+  sendBotLogMessage,
+} = require('../services/botOps.js');
+const { getBuildInfo } = require('../services/buildInfo.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('release-notes')
+    .setDescription('Post formatted release notes to #changelog')
+    .addStringOption((option) =>
+      option
+        .setName('text')
+        .setDescription('Release note details')
+        .setRequired(true)
+        .setMaxLength(2000)
+    ),
+  async execute(interaction) {
+    await addCommandExecution();
+
+    const authorized = await requireOwnerOrMaintainer(interaction);
+    if (!authorized) {
+      return;
+    }
+
+    const changelogChannel = await getChangelogChannel(interaction.guild);
+    if (!changelogChannel) {
+      await interaction.reply({
+        content: 'Unable to find #changelog in this server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const noteText = interaction.options.getString('text', true);
+    const buildInfo = getBuildInfo();
+    const embed = new EmbedBuilder()
+      .setTitle('Release Notes')
+      .setColor('#2c3e50')
+      .setTimestamp()
+      .setDescription(noteText)
+      .addFields(
+        {
+          name: 'Published By',
+          value: `${interaction.user.username} (${interaction.user.id})`,
+          inline: true,
+        },
+        { name: 'Version', value: buildInfo.version, inline: true },
+        { name: 'Git SHA', value: buildInfo.gitSha, inline: true }
+      );
+
+    await changelogChannel.send({ embeds: [embed] });
+    await interaction.reply({
+      content: 'Release notes posted to #changelog.',
+      ephemeral: true,
+    });
+
+    await sendBotLogMessage(interaction.client, interaction.guildId, {
+      content:
+        `Release notes posted by ${interaction.user.username} in #${changelogChannel.name}`,
+    });
+  },
+};

--- a/js/commands/settranslation.js
+++ b/js/commands/settranslation.js
@@ -1,0 +1,66 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { logger } = require('../logger.js');
+const { addCommandExecution } = require('../db/statsDB.js');
+const {
+  setUserTranslation,
+  isSubscribed,
+} = require('../db/subscribeDB.js');
+const {
+  getTranslationLabel,
+  normalizeTranslationCode,
+  toDiscordChoices,
+} = require('../constants/translations.js');
+const { logCommandError } = require('../services/botOps.js');
+
+const translationChoices = toDiscordChoices().slice(0, 25);
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('settranslation')
+    .setDescription('Set your default Bible translation preference')
+    .addStringOption((option) => {
+      option
+        .setName('translation')
+        .setDescription('Translation used for daily and random verses')
+        .setRequired(true);
+      for (const choice of translationChoices) {
+        option.addChoices(choice);
+      }
+      return option;
+    }),
+  async execute(interaction) {
+    await addCommandExecution();
+    logger.info(`Slash command /settranslation called by ${interaction.user.username}`);
+
+    const selectedTranslation = normalizeTranslationCode(
+      interaction.options.getString('translation')
+    );
+    const selectedLabel = getTranslationLabel(selectedTranslation);
+
+    try {
+      await setUserTranslation(interaction.user.id, selectedTranslation);
+      const subscribed = await isSubscribed(interaction.user.id);
+
+      const embed = new EmbedBuilder()
+        .setTitle('Translation preference updated')
+        .setColor('#00AA55')
+        .setTimestamp()
+        .setDescription(`Your default translation is now ${selectedLabel}.`)
+        .setFooter({
+          text: subscribed
+            ? 'This will apply to your daily verse delivery.'
+            : 'Use /subscribe to start receiving daily verses with this translation.',
+        })
+        .setThumbnail(interaction.client.user.displayAvatarURL());
+
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+    } catch (error) {
+      logger.error(error);
+      await logCommandError(interaction, error, 'Set translation command failed');
+      await interaction.reply({
+        content: 'An error occurred while updating your translation preference.',
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/js/commands/stats.js
+++ b/js/commands/stats.js
@@ -1,81 +1,40 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
-const { createCanvas, loadImage } = require('canvas');
-const { getStats } = require('../db/statsDB.js');
-const { AttachmentBuilder } = require('discord.js');
-const { version } = require('../../cfg/config.json');
-const { addCommandExecution } = require('../db/statsDB.js');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { getStats, addCommandExecution } = require('../db/statsDB.js');
+const { version } = require('../config.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName('stats')
-        .setDescription('Show bot statistics'),
-    async execute(interaction) {
-        await addCommandExecution();
-        // Fetch the statistics
-        const stats = await getStats();
-        const uptime = interaction.client.uptime;
+  data: new SlashCommandBuilder()
+    .setName('stats')
+    .setDescription('Show bot statistics'),
+  async execute(interaction) {
+    await addCommandExecution();
 
-        // Calculate uptime values
-        const days = Math.floor(uptime / 86400000);
-        const hours = Math.floor(uptime / 3600000) % 24;
-        const minutes = Math.floor(uptime / 60000) % 60;
-        const seconds = Math.floor(uptime / 1000) % 60;
+    const stats = await getStats();
+    const uptime = interaction.client.uptime || 0;
 
-        // Calculate the canvas size based on data
-        const lineHeight = 40;
-        const labelWidth = 220; // Adjust for wider labels if needed
+    const days = Math.floor(uptime / 86400000);
+    const hours = Math.floor(uptime / 3600000) % 24;
+    const minutes = Math.floor(uptime / 60000) % 60;
+    const seconds = Math.floor(uptime / 1000) % 60;
 
-        const longestLabel = Math.max(
-            `Subscribed Users: ${stats.subscribedUsersCount}`.length,
-            `Total Verses Sent: ${stats.totalVersesSent}`.length,
-            `Total Commands Executed: ${stats.totalCommandsExecuted}`.length,
-            `Total Active Guilds: ${stats.activeGuilds}`.length,
-            `Uptime: ${days}d ${hours}h ${minutes}m ${seconds}s`.length,
-            `Bot Version: ${version}`.length
-        );
+    const statsEmbed = new EmbedBuilder()
+      .setTitle('Bot Statistics')
+      .setColor('#264653')
+      .setTimestamp()
+      .addFields(
+        { name: 'Subscribed Users', value: String(stats.subscribedUsersCount), inline: true },
+        { name: 'Total Verses Sent', value: String(stats.totalVersesSent), inline: true },
+        {
+          name: 'Total Commands Executed',
+          value: String(stats.totalCommandsExecuted),
+          inline: true,
+        },
+        { name: 'Total Active Guilds', value: String(stats.activeGuilds), inline: true },
+        { name: 'Uptime', value: `${days}d ${hours}h ${minutes}m ${seconds}s`, inline: true },
+        { name: 'Bot Version', value: version, inline: true }
+      )
+      .setThumbnail(interaction.client.user.displayAvatarURL());
 
-        const canvasWidth = labelWidth + longestLabel * 12; // Adjust as needed
-
-        const canvasHeight = 170 + (lineHeight * 5) + lineHeight + 20; // Added extra space for header and version
-
-        // Create a canvas
-        const canvas = createCanvas(canvasWidth, canvasHeight);
-        const ctx = canvas.getContext('2d');
-
-        // Header background
-        ctx.fillStyle = '#264653'; // Dark blue-green header background
-        ctx.fillRect(0, 0, canvas.width, 100);
-
-        // Load and draw bot icon
-        const icon = await loadImage('assets/bible_scripture_icon.png');
-        ctx.drawImage(icon, 20, 20, 60, 60);
-
-        // Header text styles
-        ctx.fillStyle = '#FFFFFF'; // White header text
-        ctx.font = 'bold 24px Arial';
-        ctx.fillText('Bot Statistics', 90, 60);
-
-        // Data text styles
-        ctx.fillStyle = '#FFFFFF'; // White data text
-        ctx.font = '24px Arial';
-        let dataX = 140; // Adjust the starting X coordinate for data
-
-        // Data fields (left-aligned)
-        ctx.textAlign = 'left';
-        ctx.fillText(`Subscribed Users: ${stats.subscribedUsersCount}`, dataX, 170);
-        ctx.fillText(`Total Verses Sent: ${stats.totalVersesSent}`, dataX, 170 + lineHeight);
-        ctx.fillText(`Total Commands Executed: ${stats.totalCommandsExecuted}`, dataX, 170 + lineHeight * 2);
-        ctx.fillText(`Total Active Guilds: ${stats.activeGuilds}`, dataX, 170 + lineHeight * 3);
-
-        // Uptime
-        const formattedUptime = `${days}d ${hours}h ${minutes}m ${seconds}s`;
-        ctx.fillText(`Uptime: ${formattedUptime}`, dataX, 170 + lineHeight * 4);
-
-        // Bot Version
-        ctx.fillText(`Bot Version: ${version}`, dataX, 170 + lineHeight * 5); // Adjusted for extra line
-
-        // Send the canvas as an image
-        const attachment = new AttachmentBuilder(canvas.toBuffer(), 'stats.png');
-        await interaction.reply({ files: [attachment], ephemeral: true });
-    },
+    await interaction.reply({ embeds: [statsEmbed], ephemeral: true });
+  },
 };

--- a/js/commands/subscribe.js
+++ b/js/commands/subscribe.js
@@ -1,55 +1,99 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
-const { EmbedBuilder } = require('discord.js');
-const path = require('path');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { logger } = require('../logger.js');
-const fs = require('fs/promises');
 const sendDailyVerse = require('../verseSender');
-const { addSubscribedUser, isSubscribed } = require('../db/subscribeDB.js');
+const {
+  addSubscribedUser,
+  isSubscribed,
+  setUserTranslation,
+} = require('../db/subscribeDB.js');
 const { addCommandExecution, updateSubscribedUsersCount } = require('../db/statsDB.js');
+const {
+  DEFAULT_TRANSLATION,
+  getTranslationLabel,
+  normalizeTranslationCode,
+  toDiscordChoices,
+} = require('../constants/translations.js');
+const { logCommandError } = require('../services/botOps.js');
 
-const dataFilePath = path.join(__dirname, '../../db/subscribed_users.json');
+const translationChoices = toDiscordChoices().slice(0, 25);
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName('subscribe')
-        .setDescription('Subscribe to daily bible verses'),
-    async execute(interaction) {
-        await addCommandExecution();
-        logger.info(`Slash command /subscribe called by ${interaction.user.username}`);
-        const userID = interaction.user.id;
+  data: new SlashCommandBuilder()
+    .setName('subscribe')
+    .setDescription('Subscribe to daily Bible verses')
+    .addStringOption((option) => {
+      option
+        .setName('translation')
+        .setDescription('Set your preferred Bible translation');
+      for (const choice of translationChoices) {
+        option.addChoices(choice);
+      }
+      return option;
+    }),
+  async execute(interaction) {
+    await addCommandExecution();
+    logger.info(`Slash command /subscribe called by ${interaction.user.username}`);
 
-        try {
+    const userID = interaction.user.id;
+    const translationInput = interaction.options.getString('translation');
+    const selectedTranslation = normalizeTranslationCode(
+      translationInput || DEFAULT_TRANSLATION
+    );
+    const selectedTranslationLabel = getTranslationLabel(selectedTranslation);
 
-            if (await isSubscribed(userID)) {
-                logger.debug(`${interaction.user.username} is already subscribed`);
-                const embed = new EmbedBuilder()
-                    .setTitle('🙏 You are already subscribed! 🙏')
-                    .setColor('#FF0000')
-                    .setTimestamp()
-                    .setDescription('You are already subscribed to daily bible verses.')
-                    .setFooter({ text: 'You can unsubscribe at any time by using the /unsubscribe command.'})
-                    .setThumbnail(interaction.client.user.displayAvatarURL())
-
-                await interaction.reply({ embeds: [embed], ephemeral: true });
-            } else {
-                logger.debug(`${interaction.user.username} is not subscribed`);
-                await addSubscribedUser(userID);
-                await updateSubscribedUsersCount();
-                const embed = new EmbedBuilder()
-                    .setTitle('🙏 You have been subscribed! 🙏')
-                    .setColor('#00FF00')
-                    .setTimestamp()
-                    .setDescription('You will now receive daily bible verses.')
-                    .setFooter({ text: 'You can unsubscribe at any time by using the /unsubscribe command.'})
-                    .setThumbnail(interaction.client.user.displayAvatarURL())
-
-                await interaction.reply({ embeds: [embed], ephemeral: true });
-                
-                await sendDailyVerse(interaction.client, interaction.user, 'votd');
-            }
-        } catch (error) {
-            logger.error(error);
-            await interaction.reply({ content: 'An error occurred while processing your subscription request.', ephemeral: true });
+    try {
+      if (await isSubscribed(userID)) {
+        if (translationInput) {
+          await setUserTranslation(userID, selectedTranslation);
         }
+
+        const embed = new EmbedBuilder()
+          .setTitle('You are already subscribed')
+          .setColor('#FF0000')
+          .setTimestamp()
+          .setDescription(
+            `You are already subscribed to daily Bible verses.\nCurrent translation: ${selectedTranslationLabel}.`
+          )
+          .setFooter({
+            text: 'Use /settranslation to update your translation preference any time.',
+          })
+          .setThumbnail(interaction.client.user.displayAvatarURL());
+
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+        return;
+      }
+
+      await addSubscribedUser(userID, selectedTranslation);
+      await updateSubscribedUsersCount();
+
+      const embed = new EmbedBuilder()
+        .setTitle('You have been subscribed')
+        .setColor('#00AA55')
+        .setTimestamp()
+        .setDescription(
+          `You will now receive daily Bible verses.\nTranslation: ${selectedTranslationLabel}.`
+        )
+        .setFooter({
+          text: 'You can unsubscribe at any time with /unsubscribe.',
+        })
+        .setThumbnail(interaction.client.user.displayAvatarURL());
+
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+
+      await sendDailyVerse(interaction.client, userID, 'votd', {
+        translation: selectedTranslation,
+      });
+    } catch (error) {
+      logger.error(error);
+      await logCommandError(interaction, error, 'Subscribe command failed');
+      const message =
+        'An error occurred while processing your subscription request.';
+
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ content: message, ephemeral: true });
+      } else {
+        await interaction.reply({ content: message, ephemeral: true });
+      }
     }
+  },
 };

--- a/js/commands/support.js
+++ b/js/commands/support.js
@@ -1,20 +1,24 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
-const { EmbedBuilder } = require('discord.js');
-const { version } = require('../../cfg/config.json');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { version } = require('../config.js');
+const { addCommandExecution } = require('../db/statsDB.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName('support')
-        .setDescription('Get support and report issues'),
-    execute(interaction) {
-        const supportEmbed = new EmbedBuilder()
-            .setTitle('Need Support or Found a Bug?')
-            .setColor('#FF0000')
-            .setTimestamp()
-            .setDescription(`If you need support, found a bug, or want to make a feature request, please visit our [Issue Tracker](https://github.com/michaelpa-dev/Daily-Bible-Verse-Bot/issues) to report the issue or request.`)
-            .setFooter({ text: `Bot Version: ${version}` })
-            .setThumbnail(interaction.client.user.displayAvatarURL());
+  data: new SlashCommandBuilder()
+    .setName('support')
+    .setDescription('Get support and report issues'),
+  async execute(interaction) {
+    await addCommandExecution();
 
-        interaction.reply({ embeds: [supportEmbed], ephemeral: true });
-    },
+    const supportEmbed = new EmbedBuilder()
+      .setTitle('Need Support or Found a Bug?')
+      .setColor('#FF0000')
+      .setTimestamp()
+      .setDescription(
+        'If you need support, found a bug, or want to make a feature request, please open an issue at: https://github.com/michaelpa-dev/Daily-Bible-Verse-Bot/issues'
+      )
+      .setFooter({ text: `Bot Version: ${version}` })
+      .setThumbnail(interaction.client.user.displayAvatarURL());
+
+    await interaction.reply({ embeds: [supportEmbed], ephemeral: true });
+  },
 };

--- a/js/commands/unsubscribe.js
+++ b/js/commands/unsubscribe.js
@@ -1,52 +1,57 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
-const { EmbedBuilder } = require('discord.js');
-const path = require('path');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { logger } = require('../logger.js');
-const fs = require('fs/promises');
 const { removeSubscribedUser, isSubscribed } = require('../db/subscribeDB.js');
 const { addCommandExecution, updateSubscribedUsersCount } = require('../db/statsDB.js');
-
-
-
-const dataFilePath = path.join(__dirname, '../../db/subscribed_users.json');
+const { logCommandError } = require('../services/botOps.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName('unsubscribe')
-        .setDescription('Unsubscribe from daily bible verses'),
-    async execute(interaction) {
-        await addCommandExecution();
-        logger.info(`Slash command /unsubscribe called by ${interaction.user.username}`);
-        const userID = interaction.user.id;
+  data: new SlashCommandBuilder()
+    .setName('unsubscribe')
+    .setDescription('Unsubscribe from daily Bible verses'),
+  async execute(interaction) {
+    await addCommandExecution();
+    logger.info(`Slash command /unsubscribe called by ${interaction.user.username}`);
 
-        try {
-            if (isSubscribed(userID)) {
-                await removeSubscribedUser(userID);
-                await updateSubscribedUsersCount();
-                const embed = new EmbedBuilder()
-                    .setTitle('You have been unsubscribed!')
-                    .setColor('#FF0000')
-                    .setTimestamp()
-                    .setDescription('You will no longer receive daily bible verses.')
-                    .setFooter({ text: 'You can subscribe again anytime using the /subscribe command.' })
-                    .setThumbnail(interaction.client.user.displayAvatarURL());
+    const userID = interaction.user.id;
 
-                await interaction.reply({ embeds: [embed], ephemeral: true });
-            } else {
-                logger.debug(`${interaction.user.username} is not subscribed`);
-                const embed = new EmbedBuilder()
-                    .setTitle('You are not subscribed!')
-                    .setColor('#FF0000')
-                    .setTimestamp()
-                    .setDescription('You are not currently subscribed to daily bible verses.')
-                    .setFooter({ text: 'You can subscribe using the /subscribe command.' })
-                    .setThumbnail(interaction.client.user.displayAvatarURL());
+    try {
+      if (await isSubscribed(userID)) {
+        await removeSubscribedUser(userID);
+        await updateSubscribedUsersCount();
 
-                await interaction.reply({ embeds: [embed], ephemeral: true });
-            }
-        } catch (error) {
-            logger.error(error);
-            await interaction.reply({ content: 'An error occurred while processing your unsubscription request.', ephemeral: true });
-        }
+        const embed = new EmbedBuilder()
+          .setTitle('You have been unsubscribed')
+          .setColor('#FF0000')
+          .setTimestamp()
+          .setDescription('You will no longer receive daily Bible verses.')
+          .setFooter({
+            text: 'You can subscribe again any time using /subscribe.',
+          })
+          .setThumbnail(interaction.client.user.displayAvatarURL());
+
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+        return;
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle('You are not subscribed')
+        .setColor('#FF0000')
+        .setTimestamp()
+        .setDescription('You are not currently subscribed to daily Bible verses.')
+        .setFooter({ text: 'Use /subscribe to start daily verses.' })
+        .setThumbnail(interaction.client.user.displayAvatarURL());
+
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+    } catch (error) {
+      logger.error(error);
+      await logCommandError(interaction, error, 'Unsubscribe command failed');
+      const message =
+        'An error occurred while processing your unsubscription request.';
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ content: message, ephemeral: true });
+      } else {
+        await interaction.reply({ content: message, ephemeral: true });
+      }
     }
+  },
 };

--- a/js/commands/version.js
+++ b/js/commands/version.js
@@ -1,0 +1,24 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { addCommandExecution } = require('../db/statsDB.js');
+const { getBuildInfo } = require('../services/buildInfo.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('version')
+    .setDescription('Show bot semantic version and git SHA'),
+  async execute(interaction) {
+    await addCommandExecution();
+    const { version, gitSha } = getBuildInfo();
+
+    const embed = new EmbedBuilder()
+      .setTitle('Build Version')
+      .setColor('#2980b9')
+      .setTimestamp()
+      .addFields(
+        { name: 'Version', value: version, inline: true },
+        { name: 'Git SHA', value: gitSha, inline: true }
+      );
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  },
+};

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+const { DEFAULT_TRANSLATION } = require('./constants/translations.js');
+
+const projectRoot = path.join(__dirname, '..');
+const configFilePath = path.join(projectRoot, 'cfg', 'config.json');
+const configSamplePath = path.join(projectRoot, 'cfg', 'config-sample.json');
+
+function readJsonConfig(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    return {};
+  }
+}
+
+const primaryConfig = readJsonConfig(configFilePath);
+const fallbackConfig = readJsonConfig(configSamplePath);
+
+function pickConfigValue(key, defaultValue) {
+  const environmentKey = key
+    .replace(/[A-Z]/g, (letter) => `_${letter}`)
+    .toUpperCase();
+
+  if (Object.prototype.hasOwnProperty.call(process.env, environmentKey)) {
+    return process.env[environmentKey];
+  }
+
+  if (Object.prototype.hasOwnProperty.call(primaryConfig, key)) {
+    return primaryConfig[key];
+  }
+
+  if (Object.prototype.hasOwnProperty.call(fallbackConfig, key)) {
+    return fallbackConfig[key];
+  }
+
+  return defaultValue;
+}
+
+module.exports = {
+  botToken: pickConfigValue('botToken', process.env.BOT_TOKEN || ''),
+  bibleApiUrl: pickConfigValue(
+    'bibleApiUrl',
+    'https://labs.bible.org/api/?type=json&passage='
+  ),
+  translationApiUrl: pickConfigValue('translationApiUrl', 'https://bible-api.com/'),
+  version: pickConfigValue('version', '0.1.1'),
+  defaultTranslation: String(
+    pickConfigValue('defaultTranslation', DEFAULT_TRANSLATION)
+  ).toLowerCase(),
+  logLevel: pickConfigValue('logLevel', 'debug'),
+};

--- a/js/constants/devServerSpec.js
+++ b/js/constants/devServerSpec.js
@@ -1,0 +1,187 @@
+const { PermissionFlagsBits } = require('discord.js');
+
+const TARGET_DEV_GUILD_ID = '1471943418002280451';
+const MAINTAINER_ROLE_NAME = 'Maintainer';
+
+const ROLE_SPECS = [
+  {
+    name: 'Maintainer',
+    requiredPermissions: [
+      PermissionFlagsBits.ManageGuild,
+      PermissionFlagsBits.ManageChannels,
+      PermissionFlagsBits.ManageRoles,
+      PermissionFlagsBits.ManageMessages,
+      PermissionFlagsBits.ViewAuditLog,
+    ],
+  },
+  { name: 'Reviewer', requiredPermissions: [] },
+  { name: 'Tester', requiredPermissions: [] },
+  { name: 'Contributor', requiredPermissions: [] },
+  { name: 'Muted', requiredPermissions: [] },
+];
+
+const CATEGORY_SPECS = [
+  {
+    name: '📌 INFO',
+    channels: [
+      {
+        name: 'welcome',
+        type: 'text',
+        topic: 'Start here. Read onboarding, server purpose, and how to participate.',
+      },
+      {
+        name: 'rules-and-safety',
+        type: 'text',
+        topic: 'Community rules, moderation expectations, and safety policy updates.',
+      },
+      {
+        name: 'roadmap',
+        type: 'text',
+        topic: 'Product direction, milestones, and prioritized upcoming work.',
+      },
+      {
+        name: 'changelog',
+        type: 'text',
+        topic: 'Release notes and notable changes shipped to the bot.',
+      },
+    ],
+  },
+  {
+    name: '🛠️ DEVELOPMENT',
+    channels: [
+      {
+        name: 'dev-chat',
+        type: 'text',
+        topic: 'General engineering discussion and implementation coordination.',
+      },
+      {
+        name: 'help-requests',
+        type: 'text',
+        topic: 'Ask for coding help, debugging support, or pairing.',
+      },
+      {
+        name: 'ideas-backlog',
+        type: 'text',
+        topic: 'Feature ideas and rough proposals before prioritization.',
+      },
+      {
+        name: 'design-decisions',
+        type: 'text',
+        topic: 'Architecture Decision Records (ADRs), tradeoffs, and final decisions.',
+      },
+      {
+        name: 'pr-reviews',
+        type: 'text',
+        topic: 'Share pull requests and request review feedback.',
+      },
+      {
+        name: 'qa-testing',
+        type: 'text',
+        topic: 'Test plans, bug reports, reproduction steps, and verification notes.',
+      },
+    ],
+  },
+  {
+    name: '🤖 BOT OPS',
+    channels: [
+      {
+        name: 'bot-status',
+        type: 'text',
+        topic: 'Service heartbeat, uptime summaries, and operational state.',
+      },
+      {
+        name: 'bot-logs',
+        type: 'text',
+        topic: 'Structured bot logs and command/runtime error events (read-only for humans).',
+      },
+      {
+        name: 'alerts',
+        type: 'text',
+        topic: 'High-priority operational alerts that require maintainer attention.',
+      },
+    ],
+  },
+  {
+    name: '🔊 VOICE',
+    channels: [
+      {
+        name: 'Dev Huddle',
+        type: 'voice',
+        topic: 'Live discussion, pairing sessions, and standups.',
+      },
+    ],
+  },
+];
+
+const CHANNEL_NAMES = {
+  welcome: 'welcome',
+  rules: 'rules-and-safety',
+  roadmap: 'roadmap',
+  changelog: 'changelog',
+  devChat: 'dev-chat',
+  helpRequests: 'help-requests',
+  ideasBacklog: 'ideas-backlog',
+  designDecisions: 'design-decisions',
+  prReviews: 'pr-reviews',
+  qaTesting: 'qa-testing',
+  botStatus: 'bot-status',
+  botLogs: 'bot-logs',
+  alerts: 'alerts',
+};
+
+const TEMPLATE_MESSAGES = [
+  {
+    channelName: CHANNEL_NAMES.welcome,
+    marker: '[dbvb-template:welcome]',
+    content: [
+      '[dbvb-template:welcome]',
+      '# Welcome to Daily Bible Verse Bot Dev Server',
+      'Use this server to build, test, and release safely.',
+      '',
+      '## Start Here',
+      '1. Read `#rules-and-safety`.',
+      '2. Check the current priority in `#roadmap`.',
+      '3. Ask implementation questions in `#help-requests`.',
+      '4. Post PR links in `#pr-reviews`.',
+    ].join('\n'),
+  },
+  {
+    channelName: CHANNEL_NAMES.qaTesting,
+    marker: '[dbvb-template:qa-testing]',
+    content: [
+      '[dbvb-template:qa-testing]',
+      '# Bug Report Template',
+      '- Summary:',
+      '- Environment (local/prod):',
+      '- Steps to reproduce:',
+      '- Expected result:',
+      '- Actual result:',
+      '- Logs / screenshots:',
+      '- Regression from previous version? (yes/no):',
+    ].join('\n'),
+  },
+  {
+    channelName: CHANNEL_NAMES.designDecisions,
+    marker: '[dbvb-template:design-decisions]',
+    content: [
+      '[dbvb-template:design-decisions]',
+      '# Decision Record Template',
+      '- Context:',
+      '- Decision:',
+      '- Alternatives considered:',
+      '- Consequences:',
+      '- Rollback plan:',
+      '- Owner:',
+      '- Date:',
+    ].join('\n'),
+  },
+];
+
+module.exports = {
+  CATEGORY_SPECS,
+  CHANNEL_NAMES,
+  MAINTAINER_ROLE_NAME,
+  ROLE_SPECS,
+  TARGET_DEV_GUILD_ID,
+  TEMPLATE_MESSAGES,
+};

--- a/js/constants/translations.js
+++ b/js/constants/translations.js
@@ -1,0 +1,59 @@
+const DEFAULT_TRANSLATION = 'web';
+
+const SUPPORTED_TRANSLATIONS = [
+  { label: 'World English Bible', value: 'web' },
+  { label: 'King James Version', value: 'kjv' },
+  { label: 'American Standard Version (1901)', value: 'asv' },
+  { label: 'Bible in Basic English', value: 'bbe' },
+  { label: 'Darby Bible', value: 'darby' },
+  { label: 'Douay-Rheims 1899 American Edition', value: 'dra' },
+  { label: 'World English Bible, British Edition', value: 'webbe' },
+  { label: "Young's Literal Translation (NT only)", value: 'ylt' },
+];
+
+const supportedTranslationSet = new Set(
+  SUPPORTED_TRANSLATIONS.map((translation) => translation.value)
+);
+
+function normalizeTranslationCode(rawCode) {
+  if (typeof rawCode !== 'string' || rawCode.trim().length === 0) {
+    return DEFAULT_TRANSLATION;
+  }
+
+  const normalizedCode = rawCode.trim().toLowerCase();
+  return supportedTranslationSet.has(normalizedCode)
+    ? normalizedCode
+    : DEFAULT_TRANSLATION;
+}
+
+function isSupportedTranslation(rawCode) {
+  if (typeof rawCode !== 'string') {
+    return false;
+  }
+
+  return supportedTranslationSet.has(rawCode.trim().toLowerCase());
+}
+
+function getTranslationLabel(code) {
+  const normalizedCode = normalizeTranslationCode(code);
+  const match = SUPPORTED_TRANSLATIONS.find(
+    (translation) => translation.value === normalizedCode
+  );
+  return match ? match.label : 'World English Bible';
+}
+
+function toDiscordChoices() {
+  return SUPPORTED_TRANSLATIONS.map((translation) => ({
+    name: translation.label,
+    value: translation.value,
+  }));
+}
+
+module.exports = {
+  DEFAULT_TRANSLATION,
+  SUPPORTED_TRANSLATIONS,
+  getTranslationLabel,
+  isSupportedTranslation,
+  normalizeTranslationCode,
+  toDiscordChoices,
+};

--- a/js/db/database.js
+++ b/js/db/database.js
@@ -1,0 +1,233 @@
+const fs = require('fs');
+const path = require('path');
+const { logger } = require('../logger.js');
+const { normalizeTranslationCode } = require('../constants/translations.js');
+
+let DatabaseSync;
+try {
+  ({ DatabaseSync } = require('node:sqlite'));
+} catch (error) {
+  throw new Error(
+    'SQLite persistence requires a Node.js runtime with support for node:sqlite.'
+  );
+}
+
+const DEFAULT_DB_PATH = path.join(__dirname, '../../db/bot.sqlite');
+const DEFAULT_LEGACY_DB_DIR = path.join(__dirname, '../../db');
+
+let dbPromise = null;
+
+class SQLiteAdapter {
+  constructor(database) {
+    this.database = database;
+  }
+
+  async exec(sql) {
+    this.database.exec(sql);
+  }
+
+  async run(sql, ...params) {
+    return this.database.prepare(sql).run(...params);
+  }
+
+  async get(sql, ...params) {
+    return this.database.prepare(sql).get(...params);
+  }
+
+  async all(sql, ...params) {
+    return this.database.prepare(sql).all(...params);
+  }
+
+  async close() {
+    this.database.close();
+  }
+}
+
+function getDatabasePath() {
+  return process.env.DB_PATH ? path.resolve(process.env.DB_PATH) : DEFAULT_DB_PATH;
+}
+
+function getLegacyDatabaseDirectory() {
+  return process.env.LEGACY_DB_DIR
+    ? path.resolve(process.env.LEGACY_DB_DIR)
+    : DEFAULT_LEGACY_DB_DIR;
+}
+
+function normalizeTranslation(rawTranslation) {
+  return normalizeTranslationCode(rawTranslation);
+}
+
+async function migrateSubscriptionsFromJson(db) {
+  const legacyFilePath = path.join(
+    getLegacyDatabaseDirectory(),
+    'subscribed_users.json'
+  );
+  if (!fs.existsSync(legacyFilePath)) {
+    return;
+  }
+
+  try {
+    const fileContents = fs.readFileSync(legacyFilePath, 'utf8').trim();
+    if (!fileContents) {
+      return;
+    }
+
+    const users = JSON.parse(fileContents);
+    if (!Array.isArray(users)) {
+      logger.warn(`Legacy subscribers file has invalid format: ${legacyFilePath}`);
+      return;
+    }
+
+    for (const user of users) {
+      if (!user || typeof user.id !== 'string' || user.id.trim().length === 0) {
+        continue;
+      }
+
+      const userId = user.id.trim();
+      const translation = normalizeTranslation(user.translation);
+
+      await db.run(
+        `INSERT INTO user_preferences (user_id, translation)
+         VALUES (?, ?)
+         ON CONFLICT(user_id) DO UPDATE SET
+           translation = excluded.translation,
+           updated_at = CURRENT_TIMESTAMP`,
+        userId,
+        translation
+      );
+      await db.run(
+        `INSERT INTO subscriptions (user_id)
+         VALUES (?)
+         ON CONFLICT(user_id) DO NOTHING`,
+        userId
+      );
+    }
+  } catch (error) {
+    logger.error(`Failed to migrate legacy subscribers file: ${legacyFilePath}`, error);
+  }
+}
+
+async function migrateStatsFromJson(db) {
+  const legacyFilePath = path.join(getLegacyDatabaseDirectory(), 'stats.json');
+  if (!fs.existsSync(legacyFilePath)) {
+    return;
+  }
+
+  try {
+    const fileContents = fs.readFileSync(legacyFilePath, 'utf8').trim();
+    if (!fileContents) {
+      return;
+    }
+
+    const legacyStats = JSON.parse(fileContents);
+    if (!legacyStats || typeof legacyStats !== 'object') {
+      logger.warn(`Legacy stats file has invalid format: ${legacyFilePath}`);
+      return;
+    }
+
+    const currentStats = await db.get(
+      `SELECT total_verses_sent, total_commands_executed, active_guilds
+       FROM stats
+       WHERE id = 1`
+    );
+
+    const mergedTotalVerses = Math.max(
+      Number(currentStats?.total_verses_sent || 0),
+      Number(legacyStats.totalVersesSent || 0)
+    );
+    const mergedTotalCommands = Math.max(
+      Number(currentStats?.total_commands_executed || 0),
+      Number(legacyStats.totalCommandsExecuted || 0)
+    );
+    const mergedActiveGuilds = Math.max(
+      Number(currentStats?.active_guilds || 0),
+      Number(legacyStats.activeGuilds || 0)
+    );
+
+    await db.run(
+      `UPDATE stats
+       SET total_verses_sent = ?,
+           total_commands_executed = ?,
+           active_guilds = ?
+       WHERE id = 1`,
+      mergedTotalVerses,
+      mergedTotalCommands,
+      mergedActiveGuilds
+    );
+  } catch (error) {
+    logger.error(`Failed to migrate legacy stats file: ${legacyFilePath}`, error);
+  }
+}
+
+async function initializeDatabase() {
+  const databasePath = getDatabasePath();
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+
+  const database = new DatabaseSync(databasePath);
+  const db = new SQLiteAdapter(database);
+
+  await db.exec('PRAGMA foreign_keys = ON;');
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS user_preferences (
+      user_id TEXT PRIMARY KEY,
+      translation TEXT NOT NULL DEFAULT 'web',
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS subscriptions (
+      user_id TEXT PRIMARY KEY,
+      subscribed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (user_id) REFERENCES user_preferences(user_id) ON DELETE CASCADE
+    );
+  `);
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS stats (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      total_verses_sent INTEGER NOT NULL DEFAULT 0,
+      total_commands_executed INTEGER NOT NULL DEFAULT 0,
+      active_guilds INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+
+  await db.run(
+    `INSERT INTO stats (id, total_verses_sent, total_commands_executed, active_guilds)
+     VALUES (1, 0, 0, 0)
+     ON CONFLICT(id) DO NOTHING;`
+  );
+
+  await migrateSubscriptionsFromJson(db);
+  await migrateStatsFromJson(db);
+
+  logger.debug(`Database initialized at: ${databasePath}`);
+  return db;
+}
+
+async function getDatabase() {
+  if (!dbPromise) {
+    dbPromise = initializeDatabase();
+  }
+
+  return dbPromise;
+}
+
+async function closeDatabase() {
+  if (!dbPromise) {
+    return;
+  }
+
+  const db = await dbPromise;
+  await db.close();
+  dbPromise = null;
+}
+
+module.exports = {
+  getDatabase,
+  closeDatabase,
+  getDatabasePath,
+  getLegacyDatabaseDirectory,
+};

--- a/js/db/subscribeDB.js
+++ b/js/db/subscribeDB.js
@@ -1,73 +1,202 @@
-//crud js file for subscribed_users.json in the /db folder
-const fs = require('fs');
-const path = require('path');
 const { logger } = require('../logger.js');
-const subscribedUsersFile = path.join(__dirname, '../../db/subscribed_users.json');
+const { getDatabase } = require('./database.js');
+const {
+  DEFAULT_TRANSLATION,
+  normalizeTranslationCode,
+} = require('../constants/translations.js');
 
-// Function to get all subscribed users
+function normalizeTranslation(rawTranslation) {
+  return normalizeTranslationCode(rawTranslation);
+}
+
+function normalizeUserId(userId) {
+  if (typeof userId !== 'string' || userId.trim().length === 0) {
+    return null;
+  }
+
+  return userId.trim();
+}
+
 async function getSubscribedUsers() {
-    try {
-        logger.debug('Fetching subscribed users from file: ' + subscribedUsersFile);
-        const subscribedUsers = JSON.parse(fs.readFileSync(subscribedUsersFile)).map(item => ({ id: item.id }));
-        logger.debug('Subscribed users fetched successfully. Count: ' + subscribedUsers.length + '.');
-        return subscribedUsers;
-    } catch (error) {
-        logger.error('Error fetching subscribed users:', error);
-        return [];
-    }
+  try {
+    const db = await getDatabase();
+    const rows = await db.all(
+      `SELECT s.user_id AS id, COALESCE(p.translation, ?) AS translation
+       FROM subscriptions s
+       LEFT JOIN user_preferences p ON p.user_id = s.user_id
+       ORDER BY s.subscribed_at ASC`,
+      DEFAULT_TRANSLATION
+    );
+
+    return rows.map((row) => ({
+      id: row.id,
+      translation: normalizeTranslation(row.translation),
+    }));
+  } catch (error) {
+    logger.error('Error fetching subscribed users:', error);
+    return [];
+  }
 }
 
-// Function to add a subscribed user
-async function addSubscribedUser(userId) {
-    try {
-        logger.debug('Adding subscribed user to file: ' + subscribedUsersFile);
-        const subscribedUsers = await getSubscribedUsers();
-        subscribedUsers.push({ id: userId });
-        fs.writeFileSync(subscribedUsersFile, JSON.stringify(subscribedUsers, null, 2));
-        logger.info('Subscribed user added successfully.');
-    } catch (error) {
-        logger.error('Error adding subscribed user:', error);
-    }
+async function getSubscribedUsersCount() {
+  try {
+    const db = await getDatabase();
+    const row = await db.get('SELECT COUNT(*) AS count FROM subscriptions');
+    return Number(row?.count || 0);
+  } catch (error) {
+    logger.error('Error fetching subscribed users count:', error);
+    return 0;
+  }
 }
 
-// Function to remove a subscribed user
+async function addSubscribedUser(userId, translation = DEFAULT_TRANSLATION) {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) {
+    throw new Error('User ID is required to subscribe.');
+  }
+
+  try {
+    const db = await getDatabase();
+    const normalizedTranslation = normalizeTranslation(translation);
+
+    await db.run(
+      `INSERT INTO user_preferences (user_id, translation)
+       VALUES (?, ?)
+       ON CONFLICT(user_id) DO UPDATE SET
+         translation = excluded.translation,
+         updated_at = CURRENT_TIMESTAMP`,
+      normalizedUserId,
+      normalizedTranslation
+    );
+
+    await db.run(
+      `INSERT INTO subscriptions (user_id)
+       VALUES (?)
+       ON CONFLICT(user_id) DO NOTHING`,
+      normalizedUserId
+    );
+
+    logger.debug(
+      `Subscribed user added/updated successfully: ${normalizedUserId} (${normalizedTranslation}).`
+    );
+  } catch (error) {
+    logger.error('Error adding subscribed user:', error);
+    throw error;
+  }
+}
+
 async function removeSubscribedUser(userId) {
-    try {
-        logger.debug('Removing subscribed user from file: ' + subscribedUsersFile);
-        const subscribedUsers = await getSubscribedUsers();
-        const filteredSubscribedUsers = subscribedUsers.filter((user) => user.id !== userId);
-        fs.writeFileSync(subscribedUsersFile, JSON.stringify(filteredSubscribedUsers, null, 2));
-        logger.info('Subscribed user removed successfully.');
-    } catch (error) {
-        logger.error('Error removing subscribed user:', error);
-    }
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) {
+    return;
+  }
+
+  try {
+    const db = await getDatabase();
+    await db.run('DELETE FROM subscriptions WHERE user_id = ?', normalizedUserId);
+    logger.debug(`Subscribed user removed successfully: ${normalizedUserId}.`);
+  } catch (error) {
+    logger.error('Error removing subscribed user:', error);
+    throw error;
+  }
 }
 
-// Function to check if user is subscribed
 async function isSubscribed(userId) {
-    try {
-        logger.debug('Checking if user is subscribed.');
-        const subscribedUsers = await getSubscribedUsers();
-        const subscribedUser = subscribedUsers.find((user) => user.id === userId);
-        return subscribedUser !== undefined;
-    } catch (error) {
-        logger.error('Error checking if user is subscribed:', error);
-        return false;
-    }
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) {
+    return false;
+  }
+
+  try {
+    const db = await getDatabase();
+    const row = await db.get(
+      'SELECT 1 AS subscribed FROM subscriptions WHERE user_id = ? LIMIT 1',
+      normalizedUserId
+    );
+    return Boolean(row);
+  } catch (error) {
+    logger.error('Error checking if user is subscribed:', error);
+    return false;
+  }
 }
 
-// Function to remove all subscribed users
 async function removeAllSubscribedUsers() {
-    try {
-        logger.debug('Removing all subscribed users.');
-        fs.writeFileSync(subscribedUsersFile, JSON.stringify([], null, 2));
-        logger.info('All subscribed users removed successfully.');
-        updateSubscribedUsersCount();
-    } catch (error) {
-        logger.error('Error removing all subscribed users:', error);
+  try {
+    const db = await getDatabase();
+    await db.run('DELETE FROM subscriptions');
+    logger.debug('All subscribed users removed successfully.');
+  } catch (error) {
+    logger.error('Error removing all subscribed users:', error);
+    throw error;
+  }
+}
+
+async function setUserTranslation(userId, translation) {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) {
+    throw new Error('User ID is required to set translation.');
+  }
+
+  try {
+    const db = await getDatabase();
+    const normalizedTranslation = normalizeTranslation(translation);
+    await db.run(
+      `INSERT INTO user_preferences (user_id, translation)
+       VALUES (?, ?)
+       ON CONFLICT(user_id) DO UPDATE SET
+         translation = excluded.translation,
+         updated_at = CURRENT_TIMESTAMP`,
+      normalizedUserId,
+      normalizedTranslation
+    );
+
+    return {
+      id: normalizedUserId,
+      translation: normalizedTranslation,
+    };
+  } catch (error) {
+    logger.error('Error setting user translation:', error);
+    throw error;
+  }
+}
+
+async function getUserPreferences(userId) {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) {
+    return null;
+  }
+
+  try {
+    const db = await getDatabase();
+    const row = await db.get(
+      `SELECT user_id AS id, translation
+       FROM user_preferences
+       WHERE user_id = ?`,
+      normalizedUserId
+    );
+
+    if (!row) {
+      return null;
     }
+
+    return {
+      id: row.id,
+      translation: normalizeTranslation(row.translation),
+    };
+  } catch (error) {
+    logger.error('Error getting user preferences:', error);
+    return null;
+  }
 }
 
 module.exports = {
-    getSubscribedUsers, addSubscribedUser, removeSubscribedUser, isSubscribed, removeAllSubscribedUsers
+  DEFAULT_TRANSLATION,
+  addSubscribedUser,
+  getSubscribedUsers,
+  getSubscribedUsersCount,
+  getUserPreferences,
+  isSubscribed,
+  removeAllSubscribedUsers,
+  removeSubscribedUser,
+  setUserTranslation,
 };

--- a/js/services/bibleApi.js
+++ b/js/services/bibleApi.js
@@ -1,17 +1,103 @@
 const axios = require('axios');
 const { logger } = require('../logger.js');
-const { bibleApiUrl } = require('../../cfg/config.json');
+const { bibleApiUrl, translationApiUrl, defaultTranslation } = require('../config.js');
+const { normalizeTranslationCode } = require('../constants/translations.js');
 
-// Function to fetch a random Bible verse
-async function getRandomBibleVerse(passage) {
+function buildReferenceRequestUrl(passage) {
+  return `${bibleApiUrl}${encodeURIComponent(passage)}`;
+}
+
+function buildTranslationRequestUrl(reference, translation) {
+  const trimmedBaseUrl = translationApiUrl.endsWith('/')
+    ? translationApiUrl
+    : `${translationApiUrl}/`;
+  const encodedReference = encodeURIComponent(reference);
+  return `${trimmedBaseUrl}${encodedReference}?translation=${translation}`;
+}
+
+function buildReferenceFromVerse(verse) {
+  return `${verse.bookname} ${verse.chapter}:${verse.verse}`;
+}
+
+async function getVerseReference(passage) {
+  const requestUrl = buildReferenceRequestUrl(passage);
+
+  logger.debug(`Fetching verse reference from API: ${requestUrl}`);
+  const response = await axios.get(requestUrl, { timeout: 15000 });
+  const verse = Array.isArray(response.data) ? response.data[0] : null;
+
+  if (!verse || !verse.bookname || !verse.chapter || !verse.verse) {
+    return null;
+  }
+
+  return verse;
+}
+
+async function getTranslatedVerse(reference, translation) {
+  const requestUrl = buildTranslationRequestUrl(reference, translation);
+
+  logger.debug(`Fetching translated verse from API: ${requestUrl}`);
+  const response = await axios.get(requestUrl, {
+    timeout: 15000,
+    validateStatus: (status) => status < 500,
+  });
+
+  if (response.status !== 200 || !response.data || !Array.isArray(response.data.verses)) {
+    return null;
+  }
+
+  const verse = response.data.verses[0];
+  if (!verse) {
+    return null;
+  }
+
+  return {
+    reference: response.data.reference,
+    bookname: verse.book_name,
+    chapter: String(verse.chapter),
+    verse: String(verse.verse),
+    text: verse.text,
+    translation: response.data.translation_id || translation,
+    translationName: response.data.translation_name || translation.toUpperCase(),
+  };
+}
+
+async function getRandomBibleVerse(passage, options = {}) {
+  const normalizedPassage = typeof passage === 'string' && passage.trim().length > 0
+    ? passage.trim()
+    : 'random';
+  const normalizedTranslation = normalizeTranslationCode(
+    options.translation || defaultTranslation
+  );
+
   try {
-    logger.debug('Fetching random Bible verse from API: ' + bibleApiUrl);
-    
-    const response = await axios.get(bibleApiUrl + passage);
-    const randomVerse = response.data[0];
-    logger.info('Random Bible verse fetched successfully.  Response Code: ' + response.status);
+    const verseReferenceData = await getVerseReference(normalizedPassage);
+    if (!verseReferenceData) {
+      return null;
+    }
 
-    return randomVerse;
+    const verseReference = buildReferenceFromVerse(verseReferenceData);
+    const translatedVerse = await getTranslatedVerse(
+      verseReference,
+      normalizedTranslation
+    );
+
+    if (translatedVerse) {
+      logger.info(
+        `Bible verse fetched successfully for ${verseReference} (${translatedVerse.translation}).`
+      );
+      return translatedVerse;
+    }
+
+    logger.warn(
+      `Falling back to source verse text because translation request failed: ${normalizedTranslation}`
+    );
+    return {
+      ...verseReferenceData,
+      reference: verseReference,
+      translation: 'net',
+      translationName: 'New English Translation',
+    };
   } catch (error) {
     logger.error('Error fetching Bible verse:', error);
     return null;

--- a/js/services/bootstrapDevServer.js
+++ b/js/services/bootstrapDevServer.js
@@ -1,0 +1,576 @@
+const {
+  ChannelType,
+  PermissionFlagsBits,
+  PermissionsBitField,
+} = require('discord.js');
+const {
+  CATEGORY_SPECS,
+  CHANNEL_NAMES,
+  MAINTAINER_ROLE_NAME,
+  ROLE_SPECS,
+  TEMPLATE_MESSAGES,
+} = require('../constants/devServerSpec.js');
+const { truncateText } = require('./botOps.js');
+
+function createBootstrapReport() {
+  return {
+    created: [],
+    updated: [],
+    unchanged: [],
+    warnings: [],
+  };
+}
+
+function addReportItem(report, section, value) {
+  report[section].push(value);
+}
+
+function roleNameEquals(a, b) {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function findRoleByName(guild, roleName) {
+  return (
+    guild.roles.cache.find((role) => roleNameEquals(role.name, roleName)) || null
+  );
+}
+
+async function ensureRole(guild, roleSpec, applyChanges, report) {
+  let role = findRoleByName(guild, roleSpec.name);
+  if (!role) {
+    addReportItem(report, 'created', `Role: ${roleSpec.name}`);
+    if (applyChanges) {
+      role = await guild.roles.create({
+        name: roleSpec.name,
+        reason: 'Bootstrap dev server roles',
+      });
+    }
+  } else {
+    addReportItem(report, 'unchanged', `Role exists: ${roleSpec.name}`);
+  }
+
+  if (!role || !roleSpec.requiredPermissions.length) {
+    return role;
+  }
+
+  const rolePermissions = new PermissionsBitField(role.permissions.bitfield);
+  const missingPermissions = roleSpec.requiredPermissions.filter(
+    (permission) => !rolePermissions.has(permission)
+  );
+
+  if (missingPermissions.length === 0) {
+    return role;
+  }
+
+  const permissionNames = missingPermissions
+    .map(
+      (permission) =>
+        Object.entries(PermissionFlagsBits).find(([, bit]) => bit === permission)?.[0] ||
+        String(permission)
+    )
+    .join(', ');
+  addReportItem(
+    report,
+    'updated',
+    `Role ${roleSpec.name}: add permissions (${permissionNames})`
+  );
+
+  if (applyChanges) {
+    await role.setPermissions(rolePermissions.add(missingPermissions), 'Bootstrap role permissions');
+  }
+
+  return role;
+}
+
+function findCategoryByName(guild, categoryName) {
+  return (
+    guild.channels.cache.find(
+      (channel) =>
+        channel.type === ChannelType.GuildCategory &&
+        roleNameEquals(channel.name, categoryName)
+    ) || null
+  );
+}
+
+function findChannelByName(guild, channelName, channelType) {
+  return (
+    guild.channels.cache.find(
+      (channel) =>
+        channel.type === channelType &&
+        roleNameEquals(channel.name, channelName)
+    ) || null
+  );
+}
+
+async function ensureCategory(guild, categorySpec, applyChanges, report) {
+  let category = findCategoryByName(guild, categorySpec.name);
+
+  if (!category) {
+    addReportItem(report, 'created', `Category: ${categorySpec.name}`);
+    if (applyChanges) {
+      category = await guild.channels.create({
+        name: categorySpec.name,
+        type: ChannelType.GuildCategory,
+        reason: 'Bootstrap dev server categories',
+      });
+    }
+  } else {
+    addReportItem(report, 'unchanged', `Category exists: ${categorySpec.name}`);
+  }
+
+  return category;
+}
+
+async function ensureChannel(guild, category, channelSpec, applyChanges, report) {
+  const channelType =
+    channelSpec.type === 'voice' ? ChannelType.GuildVoice : ChannelType.GuildText;
+  let channel = findChannelByName(guild, channelSpec.name, channelType);
+
+  if (!channel) {
+    addReportItem(
+      report,
+      'created',
+      `${channelSpec.type.toUpperCase()} #${channelSpec.name} in ${category?.name || 'target category'}`
+    );
+
+    if (applyChanges) {
+      channel = await guild.channels.create({
+        name: channelSpec.name,
+        type: channelType,
+        parent: category?.id,
+        topic: channelType === ChannelType.GuildText ? channelSpec.topic : undefined,
+        reason: 'Bootstrap dev server channels',
+      });
+    }
+    return channel;
+  }
+
+  if (category && channel.parentId !== category.id) {
+    addReportItem(
+      report,
+      'updated',
+      `Channel #${channel.name}: move to category ${category.name}`
+    );
+    if (applyChanges) {
+      await channel.setParent(category.id, { lockPermissions: false });
+    }
+  }
+
+  if (
+    channelType === ChannelType.GuildText &&
+    typeof channelSpec.topic === 'string' &&
+    channelSpec.topic.trim().length > 0 &&
+    channel.topic !== channelSpec.topic
+  ) {
+    addReportItem(report, 'updated', `Channel #${channel.name}: update topic`);
+    if (applyChanges) {
+      await channel.setTopic(channelSpec.topic, 'Bootstrap channel topics');
+    }
+  }
+
+  addReportItem(report, 'unchanged', `Channel exists: #${channel.name}`);
+  return channel;
+}
+
+function overwriteSatisfies(overwrite, permissions) {
+  if (!overwrite) {
+    return false;
+  }
+
+  for (const [permission, state] of Object.entries(permissions)) {
+    const bit = PermissionFlagsBits[permission];
+    if (!bit) {
+      continue;
+    }
+
+    if (state === true && !overwrite.allow.has(bit)) {
+      return false;
+    }
+
+    if (state === false && !overwrite.deny.has(bit)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+async function ensureOverwrite(
+  channel,
+  overwriteTarget,
+  permissions,
+  label,
+  applyChanges,
+  report
+) {
+  if (!channel || !overwriteTarget) {
+    return;
+  }
+
+  const targetId = typeof overwriteTarget === 'string' ? overwriteTarget : overwriteTarget.id;
+  const existingOverwrite = channel.permissionOverwrites.cache.get(targetId);
+  if (overwriteSatisfies(existingOverwrite, permissions)) {
+    addReportItem(report, 'unchanged', `Overwrite ok: ${label} on #${channel.name}`);
+    return;
+  }
+
+  addReportItem(report, 'updated', `Overwrite: ${label} on #${channel.name}`);
+  if (applyChanges) {
+    await channel.permissionOverwrites.edit(overwriteTarget, permissions, {
+      reason: 'Bootstrap dev server permission model',
+    });
+  }
+}
+
+function isModerationChannel(channel) {
+  const channelName = channel.name.toLowerCase();
+  const parentName = channel.parent?.name?.toLowerCase() || '';
+  return channelName.includes('mod') || parentName.includes('mod');
+}
+
+async function ensurePinnedTemplate(channel, template, applyChanges, report) {
+  if (!channel || channel.type !== ChannelType.GuildText) {
+    return;
+  }
+
+  const pinnedMessages = await channel.messages.fetchPinned();
+  let templateMessage =
+    pinnedMessages.find(
+      (message) =>
+        message.author.id === channel.client.user.id &&
+        message.content.includes(template.marker)
+    ) || null;
+
+  if (!templateMessage) {
+    const recentMessages = await channel.messages.fetch({ limit: 50 });
+    templateMessage =
+      recentMessages.find(
+        (message) =>
+          message.author.id === channel.client.user.id &&
+          message.content.includes(template.marker)
+      ) || null;
+  }
+
+  if (!templateMessage) {
+    addReportItem(report, 'created', `Pinned template in #${channel.name}`);
+    if (applyChanges) {
+      templateMessage = await channel.send({ content: template.content });
+      await templateMessage.pin('Bootstrap template pin');
+    }
+    return;
+  }
+
+  if (templateMessage.content !== template.content) {
+    addReportItem(report, 'updated', `Template content refreshed in #${channel.name}`);
+    if (applyChanges) {
+      templateMessage = await templateMessage.edit({ content: template.content });
+    }
+  } else {
+    addReportItem(report, 'unchanged', `Template current in #${channel.name}`);
+  }
+
+  if (!templateMessage.pinned) {
+    addReportItem(report, 'updated', `Template pinned in #${channel.name}`);
+    if (applyChanges) {
+      await templateMessage.pin('Bootstrap template pin');
+    }
+  }
+}
+
+async function bootstrapDevServer(guild, options = {}) {
+  const applyChanges = options.applyChanges === true;
+  const report = createBootstrapReport();
+
+  const rolesByName = new Map();
+  for (const roleSpec of ROLE_SPECS) {
+    const role = await ensureRole(guild, roleSpec, applyChanges, report);
+    if (role) {
+      rolesByName.set(roleSpec.name.toLowerCase(), role);
+    }
+  }
+
+  const channelsByName = new Map();
+  for (const categorySpec of CATEGORY_SPECS) {
+    const category = await ensureCategory(guild, categorySpec, applyChanges, report);
+
+    for (const channelSpec of categorySpec.channels) {
+      const channel = await ensureChannel(
+        guild,
+        category,
+        channelSpec,
+        applyChanges,
+        report
+      );
+      if (channel) {
+        channelsByName.set(channelSpec.name.toLowerCase(), channel);
+      }
+    }
+  }
+
+  const everyoneRole = guild.roles.everyone;
+  const maintainerRole = rolesByName.get(MAINTAINER_ROLE_NAME.toLowerCase());
+  const contributorRole = rolesByName.get('contributor');
+  const reviewerRole = rolesByName.get('reviewer');
+  const testerRole = rolesByName.get('tester');
+  const mutedRole = rolesByName.get('muted');
+
+  const infoChannelNames = new Set([
+    CHANNEL_NAMES.welcome,
+    CHANNEL_NAMES.rules,
+    CHANNEL_NAMES.roadmap,
+    CHANNEL_NAMES.changelog,
+  ]);
+  const developmentChannelNames = new Set([
+    CHANNEL_NAMES.devChat,
+    CHANNEL_NAMES.helpRequests,
+    CHANNEL_NAMES.ideasBacklog,
+    CHANNEL_NAMES.designDecisions,
+    CHANNEL_NAMES.prReviews,
+    CHANNEL_NAMES.qaTesting,
+  ]);
+  const botOpsChannelNames = new Set([
+    CHANNEL_NAMES.botStatus,
+    CHANNEL_NAMES.botLogs,
+    CHANNEL_NAMES.alerts,
+  ]);
+
+  for (const channelName of infoChannelNames) {
+    const channel = channelsByName.get(channelName.toLowerCase());
+    if (!channel) {
+      addReportItem(report, 'warnings', `Missing managed channel #${channelName}`);
+      continue;
+    }
+
+    await ensureOverwrite(
+      channel,
+      everyoneRole,
+      {
+        ViewChannel: true,
+        SendMessages: false,
+        AddReactions: false,
+        CreatePublicThreads: false,
+        CreatePrivateThreads: false,
+        SendMessagesInThreads: false,
+      },
+      '@everyone read-only',
+      applyChanges,
+      report
+    );
+
+    if (maintainerRole) {
+      await ensureOverwrite(
+        channel,
+        maintainerRole,
+        {
+          SendMessages: true,
+          AddReactions: true,
+        },
+        'Maintainer write access',
+        applyChanges,
+        report
+      );
+    }
+  }
+
+  for (const channelName of developmentChannelNames) {
+    const channel = channelsByName.get(channelName.toLowerCase());
+    if (!channel) {
+      addReportItem(report, 'warnings', `Missing managed channel #${channelName}`);
+      continue;
+    }
+
+    await ensureOverwrite(
+      channel,
+      everyoneRole,
+      {
+        ViewChannel: true,
+        SendMessages: false,
+      },
+      '@everyone read-only baseline',
+      applyChanges,
+      report
+    );
+
+    for (const [role, label] of [
+      [contributorRole, 'Contributor'],
+      [reviewerRole, 'Reviewer'],
+      [testerRole, 'Tester'],
+      [maintainerRole, 'Maintainer'],
+    ]) {
+      if (!role) {
+        continue;
+      }
+
+      await ensureOverwrite(
+        channel,
+        role,
+        {
+          SendMessages: true,
+          AddReactions: true,
+          CreatePublicThreads: true,
+          SendMessagesInThreads: true,
+        },
+        `${label} write access`,
+        applyChanges,
+        report
+      );
+    }
+  }
+
+  for (const channelName of botOpsChannelNames) {
+    const channel = channelsByName.get(channelName.toLowerCase());
+    if (!channel) {
+      addReportItem(report, 'warnings', `Missing managed channel #${channelName}`);
+      continue;
+    }
+
+    await ensureOverwrite(
+      channel,
+      everyoneRole,
+      {
+        ViewChannel: true,
+        SendMessages: false,
+        AddReactions: false,
+        CreatePublicThreads: false,
+        CreatePrivateThreads: false,
+        SendMessagesInThreads: false,
+      },
+      '@everyone read-only in bot ops',
+      applyChanges,
+      report
+    );
+
+    if (maintainerRole && channelName === CHANNEL_NAMES.alerts) {
+      await ensureOverwrite(
+        channel,
+        maintainerRole,
+        {
+          SendMessages: true,
+          AddReactions: true,
+        },
+        'Maintainer alerts write access',
+        applyChanges,
+        report
+      );
+    }
+  }
+
+  const botLogChannel = channelsByName.get(CHANNEL_NAMES.botLogs.toLowerCase());
+  const botStatusChannel = channelsByName.get(CHANNEL_NAMES.botStatus.toLowerCase());
+  const alertsChannel = channelsByName.get(CHANNEL_NAMES.alerts.toLowerCase());
+
+  if (applyChanges) {
+    await guild.members.fetch();
+  }
+
+  const botMembers = guild.members.cache.filter((member) => member.user.bot);
+  for (const botMember of botMembers.values()) {
+    if (botLogChannel) {
+      await ensureOverwrite(
+        botLogChannel,
+        botMember,
+        {
+          SendMessages: true,
+          AddReactions: true,
+          EmbedLinks: true,
+          AttachFiles: true,
+        },
+        `Bot writer (${botMember.user.username})`,
+        applyChanges,
+        report
+      );
+    }
+
+    if (botStatusChannel) {
+      await ensureOverwrite(
+        botStatusChannel,
+        botMember,
+        {
+          SendMessages: true,
+          EmbedLinks: true,
+        },
+        `Bot status writer (${botMember.user.username})`,
+        applyChanges,
+        report
+      );
+    }
+
+    if (alertsChannel) {
+      await ensureOverwrite(
+        alertsChannel,
+        botMember,
+        {
+          SendMessages: true,
+          EmbedLinks: true,
+        },
+        `Bot alerts writer (${botMember.user.username})`,
+        applyChanges,
+        report
+      );
+    }
+  }
+
+  if (mutedRole) {
+    for (const channel of guild.channels.cache.values()) {
+      if (
+        channel.type !== ChannelType.GuildText &&
+        channel.type !== ChannelType.GuildAnnouncement
+      ) {
+        continue;
+      }
+
+      if (isModerationChannel(channel)) {
+        addReportItem(
+          report,
+          'unchanged',
+          `Muted overwrite skipped in moderation channel #${channel.name}`
+        );
+        continue;
+      }
+
+      await ensureOverwrite(
+        channel,
+        mutedRole,
+        {
+          SendMessages: false,
+          AddReactions: false,
+          CreatePublicThreads: false,
+          CreatePrivateThreads: false,
+          SendMessagesInThreads: false,
+        },
+        'Muted deny send',
+        applyChanges,
+        report
+      );
+    }
+  } else {
+    addReportItem(report, 'warnings', 'Muted role not found; muted channel policy not applied.');
+  }
+
+  for (const template of TEMPLATE_MESSAGES) {
+    const channel = channelsByName.get(template.channelName.toLowerCase());
+    if (!channel) {
+      addReportItem(
+        report,
+        'warnings',
+        `Template skipped because channel #${template.channelName} is missing.`
+      );
+      continue;
+    }
+
+    await ensurePinnedTemplate(channel, template, applyChanges, report);
+  }
+
+  return {
+    ...report,
+    summary: truncateText(
+      `created=${report.created.length}, updated=${report.updated.length}, unchanged=${report.unchanged.length}, warnings=${report.warnings.length}`,
+      300
+    ),
+  };
+}
+
+module.exports = {
+  bootstrapDevServer,
+  createBootstrapReport,
+};

--- a/js/services/botOps.js
+++ b/js/services/botOps.js
@@ -1,0 +1,239 @@
+const {
+  ChannelType,
+  EmbedBuilder,
+} = require('discord.js');
+const { getBuildInfo } = require('./buildInfo.js');
+const {
+  CHANNEL_NAMES,
+  TARGET_DEV_GUILD_ID,
+} = require('../constants/devServerSpec.js');
+
+const BOT_STATUS_MARKER = '[dbvb-status-message]';
+
+function formatDuration(milliseconds) {
+  const totalSeconds = Math.floor(milliseconds / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${days}d ${hours}h ${minutes}m ${seconds}s`;
+}
+
+function truncateText(value, maxLength = 1200) {
+  if (!value) {
+    return '';
+  }
+
+  const text = String(value);
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function getGuildFromClient(client, guildId = TARGET_DEV_GUILD_ID) {
+  return client?.guilds?.cache?.get(guildId) || null;
+}
+
+function findTextChannelByName(guild, channelName) {
+  if (!guild?.channels?.cache) {
+    return null;
+  }
+
+  return (
+    guild.channels.cache.find(
+      (channel) =>
+        channel.type === ChannelType.GuildText &&
+        channel.name.toLowerCase() === channelName.toLowerCase()
+    ) || null
+  );
+}
+
+async function getBotLogsChannel(client, guildId = TARGET_DEV_GUILD_ID) {
+  const guild = getGuildFromClient(client, guildId);
+  if (!guild) {
+    return null;
+  }
+
+  return findTextChannelByName(guild, CHANNEL_NAMES.botLogs);
+}
+
+async function getBotStatusChannel(client, guildId = TARGET_DEV_GUILD_ID) {
+  const guild = getGuildFromClient(client, guildId);
+  if (!guild) {
+    return null;
+  }
+
+  return findTextChannelByName(guild, CHANNEL_NAMES.botStatus);
+}
+
+async function getChangelogChannel(guild) {
+  return findTextChannelByName(guild, CHANNEL_NAMES.changelog);
+}
+
+function buildHealthEmbed(client) {
+  const buildInfo = getBuildInfo();
+  return new EmbedBuilder()
+    .setTitle('Bot Health')
+    .setColor('#1f8b4c')
+    .setTimestamp()
+    .addFields(
+      { name: 'Status', value: 'Online', inline: true },
+      { name: 'Uptime', value: formatDuration(client.uptime || 0), inline: true },
+      { name: 'Version', value: buildInfo.version, inline: true },
+      { name: 'Git SHA', value: buildInfo.gitSha, inline: true },
+      {
+        name: 'Guild Count',
+        value: String(client.guilds?.cache?.size || 0),
+        inline: true,
+      }
+    );
+}
+
+function buildBotStatusMessage(client) {
+  const buildInfo = getBuildInfo();
+  return [
+    BOT_STATUS_MARKER,
+    '**Daily Bible Verse Bot Status**',
+    `- Status: Online`,
+    `- Uptime: ${formatDuration(client.uptime || 0)}`,
+    `- Version: ${buildInfo.version}`,
+    `- Git SHA: ${buildInfo.gitSha}`,
+    `- Last Update: <t:${Math.floor(Date.now() / 1000)}:F>`,
+  ].join('\n');
+}
+
+async function upsertBotStatusMessage(client, guildId = TARGET_DEV_GUILD_ID) {
+  const statusChannel = await getBotStatusChannel(client, guildId);
+  if (!statusChannel) {
+    return null;
+  }
+
+  const messages = await statusChannel.messages.fetch({ limit: 50 });
+  const existingMessage =
+    messages.find(
+      (message) =>
+        message.author.id === client.user.id &&
+        message.content.includes(BOT_STATUS_MARKER)
+    ) || null;
+
+  const nextContent = buildBotStatusMessage(client);
+  if (!existingMessage) {
+    return statusChannel.send({ content: nextContent });
+  }
+
+  if (existingMessage.content !== nextContent) {
+    return existingMessage.edit({ content: nextContent });
+  }
+
+  return existingMessage;
+}
+
+function buildErrorLogPayload({ context, userTag, commandName, error }) {
+  const errorSummary = truncateText(error?.message || String(error), 400);
+  const stackSnippet = truncateText(error?.stack || 'No stack available', 900);
+
+  const embed = new EmbedBuilder()
+    .setTitle('Bot Error Event')
+    .setColor('#c0392b')
+    .setTimestamp()
+    .addFields(
+      { name: 'Context', value: context || 'runtime', inline: true },
+      { name: 'Command', value: commandName || 'N/A', inline: true },
+      { name: 'User', value: userTag || 'N/A', inline: true },
+      { name: 'Summary', value: errorSummary || 'Unknown error' },
+      { name: 'Stack', value: `\`\`\`\n${stackSnippet}\n\`\`\`` }
+    );
+
+  return { embeds: [embed] };
+}
+
+async function sendBotLogMessage(client, guildId, payload) {
+  try {
+    const botLogsChannel = await getBotLogsChannel(client, guildId);
+    if (!botLogsChannel) {
+      return false;
+    }
+
+    await botLogsChannel.send(payload);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function logCommandError(interaction, error, summary) {
+  const userTag = `${interaction.user.username} (${interaction.user.id})`;
+  const commandName = `/${interaction.commandName || 'unknown'}`;
+
+  return sendBotLogMessage(
+    interaction.client,
+    interaction.guildId || TARGET_DEV_GUILD_ID,
+    buildErrorLogPayload({
+      context: summary || 'command',
+      userTag,
+      commandName,
+      error,
+    })
+  );
+}
+
+async function logRuntimeError(client, error, context = 'runtime') {
+  return sendBotLogMessage(
+    client,
+    TARGET_DEV_GUILD_ID,
+    buildErrorLogPayload({
+      context,
+      userTag: 'N/A',
+      commandName: 'N/A',
+      error,
+    })
+  );
+}
+
+function buildBootstrapSummaryMessage(mode, report) {
+  const lines = [
+    `**/bootstrap-dev-server ${mode.toUpperCase()} summary**`,
+    `- Created: ${report.created.length}`,
+    `- Updated: ${report.updated.length}`,
+    `- Unchanged: ${report.unchanged.length}`,
+    `- Warnings: ${report.warnings.length}`,
+  ];
+
+  const addSection = (label, items) => {
+    if (!items.length) {
+      return;
+    }
+
+    lines.push(`\n**${label}**`);
+    for (const item of items.slice(0, 25)) {
+      lines.push(`- ${item}`);
+    }
+    if (items.length > 25) {
+      lines.push(`- ...and ${items.length - 25} more`);
+    }
+  };
+
+  addSection('Created', report.created);
+  addSection('Updated', report.updated);
+  addSection('Warnings', report.warnings);
+  return truncateText(lines.join('\n'), 3900);
+}
+
+module.exports = {
+  BOT_STATUS_MARKER,
+  buildBootstrapSummaryMessage,
+  buildHealthEmbed,
+  findTextChannelByName,
+  formatDuration,
+  getBotLogsChannel,
+  getBotStatusChannel,
+  getChangelogChannel,
+  getGuildFromClient,
+  logCommandError,
+  logRuntimeError,
+  sendBotLogMessage,
+  truncateText,
+  upsertBotStatusMessage,
+};

--- a/js/services/buildInfo.js
+++ b/js/services/buildInfo.js
@@ -1,0 +1,43 @@
+const { execSync } = require('child_process');
+const { version } = require('../config.js');
+
+let cachedGitSha = null;
+
+function resolveGitSha() {
+  if (cachedGitSha !== null) {
+    return cachedGitSha;
+  }
+
+  const environmentSha =
+    process.env.GIT_SHA ||
+    process.env.COMMIT_SHA ||
+    process.env.GITHUB_SHA ||
+    '';
+  if (environmentSha) {
+    cachedGitSha = String(environmentSha).slice(0, 12);
+    return cachedGitSha;
+  }
+
+  try {
+    const sha = execSync('git rev-parse --short HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim();
+    cachedGitSha = sha || 'unknown';
+  } catch (error) {
+    cachedGitSha = 'unknown';
+  }
+
+  return cachedGitSha;
+}
+
+function getBuildInfo() {
+  return {
+    version,
+    gitSha: resolveGitSha(),
+  };
+}
+
+module.exports = {
+  getBuildInfo,
+};

--- a/js/services/permissionUtils.js
+++ b/js/services/permissionUtils.js
@@ -1,0 +1,47 @@
+const { MAINTAINER_ROLE_NAME } = require('../constants/devServerSpec.js');
+
+function memberHasRoleByName(member, roleName) {
+  if (!member || !member.roles || !member.roles.cache) {
+    return false;
+  }
+
+  return member.roles.cache.some(
+    (role) => role.name.toLowerCase() === roleName.toLowerCase()
+  );
+}
+
+function isOwnerOrMaintainer(interaction) {
+  if (!interaction?.guild || !interaction?.user) {
+    return false;
+  }
+
+  if (interaction.guild.ownerId === interaction.user.id) {
+    return true;
+  }
+
+  return memberHasRoleByName(interaction.member, MAINTAINER_ROLE_NAME);
+}
+
+async function requireOwnerOrMaintainer(interaction, options = {}) {
+  if (isOwnerOrMaintainer(interaction)) {
+    return true;
+  }
+
+  const message =
+    options.message ||
+    'Only the server owner or members with the Maintainer role can use this command.';
+
+  if (interaction.replied || interaction.deferred) {
+    await interaction.followUp({ content: message, ephemeral: true });
+  } else {
+    await interaction.reply({ content: message, ephemeral: true });
+  }
+
+  return false;
+}
+
+module.exports = {
+  isOwnerOrMaintainer,
+  memberHasRoleByName,
+  requireOwnerOrMaintainer,
+};

--- a/js/verseSender.js
+++ b/js/verseSender.js
@@ -2,35 +2,61 @@ const { EmbedBuilder } = require('discord.js');
 const { logger } = require('./logger.js');
 const { getRandomBibleVerse } = require('./services/bibleApi');
 const { addVerseSent } = require('./db/statsDB.js');
+const { getTranslationLabel } = require('./constants/translations.js');
 
-async function sendDailyVerse(client, userId, passage) {
-  logger.debug('Sending daily verse to User: ' + userId);
-  const user = await client.users.fetch(userId);
-  if (!user) return;
+async function sendDailyVerse(client, userOrId, passage, options = {}) {
+  const resolvedUserId =
+    typeof userOrId === 'string' ? userOrId : userOrId?.id;
 
-  const randomVerse = await getRandomBibleVerse(passage);
+  if (!resolvedUserId) {
+    logger.warn('Cannot send verse because no user ID was provided.');
+    return false;
+  }
 
-  if (!randomVerse) return;
+  logger.debug(`Sending ${passage} verse to user: ${resolvedUserId}`);
+
+  const user = await client.users.fetch(resolvedUserId);
+  if (!user) {
+    return false;
+  }
+
+  const translation = options.translation;
+  const randomVerse = await getRandomBibleVerse(passage, { translation });
+
+  if (!randomVerse) {
+    return false;
+  }
 
   const verseText = randomVerse.text;
-  const verseReference = `${randomVerse.bookname} ${randomVerse.chapter}:${randomVerse.verse}`;
-  logger.debug('Sending daily verse to User: ' + user.username + ' (' + user.id + ') Verse: ' + verseText + ' ' + verseReference);
+  const verseReference =
+    randomVerse.reference ||
+    `${randomVerse.bookname} ${randomVerse.chapter}:${randomVerse.verse}`;
+  const translationLabel = randomVerse.translationName || getTranslationLabel(translation);
+  logger.debug(
+    `Sending verse to ${user.username} (${user.id}) ${verseReference} [${translationLabel}]`
+  );
+
   const embed = new EmbedBuilder()
     .setTitle('Daily Bible Verse')
     .setDescription(verseText)
     .setColor('#0099ff')
     .addFields(
       { name: 'Reference', value: verseReference },
+      { name: 'Translation', value: translationLabel },
     )
-    .setFooter({text: 'Sent by Your Daily Verse Bot from server ' })
+    .setFooter({ text: 'Sent by Daily Bible Verse Bot' })
     .setThumbnail(client.user.displayAvatarURL());
 
   try {
     await user.send({ embeds: [embed] });
-    logger.debug('Daily verse sent successfully. User: ' + user.username + ' (' + user.id + ') Verse: ' + verseReference);
-     await addVerseSent();
+    logger.debug(
+      `Verse sent successfully. User: ${user.username} (${user.id}), Verse: ${verseReference}`
+    );
+    await addVerseSent();
+    return true;
   } catch (error) {
-    logger.error('Error sending daily verse for User:' + user.username + ' (' + user.id + ')', error);
+    logger.error(`Error sending verse for user ${user.username} (${user.id})`, error);
+    return false;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,236 +1,150 @@
 {
-  "name": "discord-bot",
+  "name": "daily-bible-verse-bot",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "daily-bible-verse-bot",
+      "version": "0.2.0",
       "dependencies": {
-        "axios": "^1.4.0",
-        "canvas": "^2.11.2",
-        "collections": "^5.1.13",
-        "date-fns-tz": "^2.0.0",
-        "discord.js": "^14.12.1",
+        "axios": "^1.13.5",
+        "discord.js": "^14.25.1",
         "log4js": "^6.9.1",
-        "node-cron": "^3.0.2",
-        "pm2": "^5.3.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
-      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
-      "peer": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "node-cron": "^3.0.3",
+        "pm2": "^5.4.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=22.5.0"
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.4.tgz",
-      "integrity": "sha512-ARFKvmAkLhfkQQiNxqi0YIWqwUExvBRtvdtMFVJXvJoibsGkFrB/DWTf9byU7BTVUfsmW8w7NM55tYXR5S/iSg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.1",
-        "@discordjs/util": "^1.0.0",
-        "@sapphire/shapeshift": "^3.9.2",
-        "discord-api-types": "^0.37.50",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.3",
-        "tslib": "^2.6.1"
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.2.tgz",
-      "integrity": "sha512-LDplPy8SPbc8MYkuCdnLRGWqygAX97E8NH7gA9uz+NZ/hXknUKJHuxsOmhC6pmHnF9Zmg0kvfwrDjGsRIljt9g==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.1.tgz",
-      "integrity": "sha512-M7X4IGiSeh4znwcRGcs+49B5tBkNDn4k5bmhxJDAUhRxRHTiFAOTVUNQ6yAKySu5jZTnCbSvTYHW3w0rAzV1MA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
       "dependencies": {
-        "discord-api-types": "^0.37.41"
+        "discord-api-types": "^0.38.33"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.0.tgz",
-      "integrity": "sha512-CW9ldfzsRzUbHcS4Oqu5+Moo+yrQ5qQ9groKNxPOzcoq2nuXa/fXOXkuQtQHcTeSVXsC9cmJ56M8gBDBUyLgGA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.2",
-        "@discordjs/util": "^1.0.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.5.1",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "^0.37.50",
-        "magic-bytes.js": "^1.0.15",
-        "tslib": "^2.6.1",
-        "undici": "^5.22.1"
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.0.tgz",
-      "integrity": "sha512-U2Iiab0mo8cFe+o4ZY4GROoAetGjFYA1PhhxiXEW82LuPUjOU/seHZDtVjDpOf6n3rz4IRm84wNtgHdpqRY5CA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.0.tgz",
-      "integrity": "sha512-POiImjuQJzwCxjJs4JCtDcTjzvjVsVQbnsaoW/F03yTVdrj/xSpmgv4383AnpNEYXI+CA6ggkz37phZDsZQ1NQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.2",
-        "@discordjs/rest": "^2.0.0",
-        "@discordjs/util": "^1.0.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.5",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "^0.37.50",
-        "tslib": "^2.6.1",
-        "ws": "^8.13.0"
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
       "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@opencensus/core": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.9.tgz",
-      "integrity": "sha512-31Q4VWtbzXpVUd2m9JS6HEaPjlKvNMOiF7lWKNmXF84yUcgfAFL5re7/hjDmdyQbOp32oGc+RFV78jXIldVz6Q==",
-      "dependencies": {
-        "continuation-local-storage": "^3.2.1",
-        "log-driver": "^1.2.7",
-        "semver": "^5.5.0",
-        "shimmer": "^1.2.0",
-        "uuid": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/@opencensus/core/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@opencensus/core/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/@opencensus/propagation-b3": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@opencensus/propagation-b3/-/propagation-b3-0.0.8.tgz",
-      "integrity": "sha512-PffXX2AL8Sh0VHQ52jJC4u3T0H6wDK6N/4bg7xh4ngMYOIi13aR1kzVvX1sVDBgfGwDOkMbl4c54Xm3tlPx/+A==",
-      "dependencies": {
-        "@opencensus/core": "^0.0.8",
-        "uuid": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/@opencensus/propagation-b3/node_modules/@opencensus/core": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.8.tgz",
-      "integrity": "sha512-yUFT59SFhGMYQgX0PhoTR0LBff2BEhPrD9io1jWfF/VDbakRfs6Pq60rjv0Z7iaTav5gQlttJCX2+VPxFWCuoQ==",
-      "dependencies": {
-        "continuation-local-storage": "^3.2.1",
-        "log-driver": "^1.2.7",
-        "semver": "^5.5.0",
-        "shimmer": "^1.2.0",
-        "uuid": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/@opencensus/propagation-b3/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@opencensus/propagation-b3/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@pm2/agent": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-2.0.3.tgz",
-      "integrity": "sha512-xkqqCoTf5VsciMqN0vb9jthW7olVAi4KRFNddCc7ZkeJZ3i8QwZANr4NSH2H5DvseRFHq7MiPspRY/EWAFWWTg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-2.0.4.tgz",
+      "integrity": "sha512-n7WYvvTJhHLS2oBb1PjOtgLpMhgImOq8sXkPBw6smeg9LJBWZjiEgPKOpR8mn9UJZsB5P3W4V/MyvNnp31LKeA==",
+      "license": "AGPL-3.0",
       "dependencies": {
         "async": "~3.2.0",
         "chalk": "~3.0.0",
@@ -244,7 +158,7 @@
         "pm2-axon-rpc": "~0.7.0",
         "proxy-agent": "~6.3.0",
         "semver": "~7.5.0",
-        "ws": "~7.4.0"
+        "ws": "~7.5.10"
       }
     },
     "node_modules/@pm2/agent/node_modules/chalk": {
@@ -265,9 +179,10 @@
       "integrity": "sha512-3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw=="
     },
     "node_modules/@pm2/agent/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -285,17 +200,16 @@
       }
     },
     "node_modules/@pm2/io": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-5.0.0.tgz",
-      "integrity": "sha512-3rToDVJaRoob5Lq8+7Q2TZFruoEkdORxwzFpZaqF4bmH6Bkd7kAbdPrI/z8X6k1Meq5rTtScM7MmDgppH6aLlw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-6.0.1.tgz",
+      "integrity": "sha512-KiA+shC6sULQAr9mGZ1pg+6KVW9MF8NpG99x26Lf/082/Qy8qsTCtnJy+HQReW1A9Rdf0C/404cz0RZGZro+IA==",
+      "license": "Apache-2",
       "dependencies": {
-        "@opencensus/core": "0.0.9",
-        "@opencensus/propagation-b3": "0.0.8",
         "async": "~2.6.1",
         "debug": "~4.3.1",
         "eventemitter2": "^6.3.1",
         "require-in-the-middle": "^5.0.0",
-        "semver": "6.3.0",
+        "semver": "~7.5.4",
         "shimmer": "^1.2.0",
         "signal-exit": "^3.0.3",
         "tslib": "1.9.3"
@@ -308,6 +222,7 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -315,30 +230,25 @@
     "node_modules/@pm2/io/node_modules/eventemitter2": {
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
-    },
-    "node_modules/@pm2/io/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
     },
     "node_modules/@pm2/io/node_modules/tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@pm2/js-api": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.6.7.tgz",
-      "integrity": "sha512-jiJUhbdsK+5C4zhPZNnyA3wRI01dEc6a2GhcQ9qI38DyIk+S+C8iC3fGjcjUbt/viLYKPjlAaE+hcT2/JMQPXw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.8.0.tgz",
+      "integrity": "sha512-nmWzrA/BQZik3VBz+npRcNIu01kdBhWL0mxKmP1ciF/gTcujPTQqt027N9fc1pK9ERM8RipFhymw7RcmCyOEYA==",
+      "license": "Apache-2",
       "dependencies": {
         "async": "^2.6.3",
-        "axios": "^0.21.0",
         "debug": "~4.3.1",
         "eventemitter2": "^6.3.1",
+        "extrareqp2": "^1.0.0",
         "ws": "^7.0.0"
       },
       "engines": {
@@ -349,27 +259,22 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/@pm2/js-api/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@pm2/js-api/node_modules/eventemitter2": {
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
     },
     "node_modules/@pm2/js-api/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -395,31 +300,30 @@
       }
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
-      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=v16"
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -431,31 +335,29 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
     "node_modules/@types/node": {
-      "version": "20.4.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.8.tgz",
-      "integrity": "sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg=="
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
-      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/agent-base": {
       "version": "7.1.0",
@@ -489,14 +391,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -523,35 +417,11 @@
         "node": ">= 8"
       }
     },
-    "node_modules/aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/argparse/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
@@ -569,45 +439,22 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
-    "node_modules/async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dependencies": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      },
-      "engines": {
-        "node": "<=0.11.8 || >0.11.10"
-      }
-    },
-    "node_modules/async-listener/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/basic-ftp": {
       "version": "5.0.3",
@@ -641,21 +488,13 @@
       "resolved": "https://registry.npmjs.org/bodec/-/bodec-0.1.0.tgz",
       "integrity": "sha512-Ylo+MAo5BDUq1KA3f3R/MFhh+g8cnHmo8bz3YPGhI1znrMaf77ol1sfvYJzsw3nTE+Y2GryfDxBaR+AqpAkEHQ=="
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -666,29 +505,17 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
-        "streamsearch": "^1.1.0"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
       },
       "engines": {
-        "node": ">=10.16.0"
-      }
-    },
-    "node_modules/canvas": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
-      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.17.0",
-        "simple-get": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">= 0.4"
       }
     },
     "node_modules/charm": {
@@ -722,14 +549,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cli-tableau": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cli-tableau/-/cli-tableau-2.0.1.tgz",
@@ -753,14 +572,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/collections": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/collections/-/collections-5.1.13.tgz",
-      "integrity": "sha512-SCb6Qd+d3Z02corWQ7/mqXiXeeTdHvkP6TeFSYfGYdCFp1WrjSNZ3j6y8Y3T/7osGEe0iOcU2g1d346l99m4Lg==",
-      "dependencies": {
-        "weak-map": "~1.0.x"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -777,18 +588,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -800,25 +604,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
-    },
-    "node_modules/continuation-local-storage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dependencies": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
-      }
     },
     "node_modules/croner": {
       "version": "4.1.97",
@@ -836,30 +621,6 @@
       "integrity": "sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
-      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
-      "peerDependencies": {
-        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/date-format": {
@@ -891,17 +652,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -919,64 +669,55 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
-    },
-    "node_modules/detect-libc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/discord-api-types": {
-      "version": "0.37.52",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.52.tgz",
-      "integrity": "sha512-TP99aMgY6rHuDIy056GDm1j2nGOcaLbFpjVbvAmv6N6vhkjHNqHXCHVqKtGisaQ8D15slbxTHNl/SSkPdx2syg=="
+      "version": "0.38.39",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.39.tgz",
+      "integrity": "sha512-XRdDQvZvID1XvcFftjSmd4dcmMi/RL/jSy5sduBDAvCGFcNFHThdIQXCEBDZFe52lCNEzuIL0QJoKYAmRmxLUA=="
     },
     "node_modules/discord.js": {
-      "version": "14.12.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.12.1.tgz",
-      "integrity": "sha512-gGjhTkauIPgFXxpBl0UZgyehrKhDe90cIS8Hn1xFBYQ63EuUAkKoUqRNmc/pcla6DD16s4cUz5tAbdSpXivnxw==",
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
       "dependencies": {
-        "@discordjs/builders": "^1.6.4",
-        "@discordjs/collection": "^1.5.2",
-        "@discordjs/formatters": "^0.3.1",
-        "@discordjs/rest": "^2.0.0",
-        "@discordjs/util": "^1.0.0",
-        "@discordjs/ws": "^1.0.0",
-        "@sapphire/snowflake": "^3.5.1",
-        "@types/ws": "^8.5.5",
-        "discord-api-types": "^0.37.50",
-        "fast-deep-equal": "^3.1.3",
-        "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.6.1",
-        "undici": "^5.22.1",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
-        "shimmer": "^1.2.0"
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
@@ -987,6 +728,51 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1053,6 +839,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
       "integrity": "sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg=="
     },
+    "node_modules/extrareqp2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/extrareqp2/-/extrareqp2-1.0.0.tgz",
+      "integrity": "sha512-Gum0g1QYb6wpPJCVypWP3bbIuaibcFiJcpuPM10YSXp/tzqi84x9PJageob+eN4xVRIOto4wjSGNLyMD54D2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1069,9 +864,10 @@
       "integrity": "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw=="
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1085,15 +881,16 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -1104,12 +901,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -1129,33 +929,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1170,27 +943,49 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "node_modules/gauge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-uri": {
@@ -1217,25 +1012,6 @@
       "resolved": "https://registry.npmjs.org/git-sha1/-/git-sha1-0.1.2.tgz",
       "integrity": "sha512-2e/nZezdVlyCopOCYHeW0onkbZg7xP1Ad6pndPy1rCygeRykefUS6r7oA5cJRGEFvseiaz5a/qUHFVX1dd6Isg=="
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1247,21 +1023,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1271,10 +1048,44 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.0",
@@ -1311,29 +1122,19 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "node_modules/ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1347,11 +1148,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1363,14 +1168,6 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -1388,6 +1185,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1401,6 +1199,18 @@
         "culvert": "^0.1.2",
         "git-sha1": "^0.1.2",
         "pako": "^0.2.5"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-stringify-safe": {
@@ -1426,22 +1236,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
-    },
-    "node_modules/log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-      "engines": {
-        "node": ">=0.8.6"
-      }
     },
     "node_modules/log4js": {
       "version": "6.9.1",
@@ -1467,36 +1270,24 @@
       }
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.15.tgz",
-      "integrity": "sha512-bpRmwbRHqongRhA+mXzbLWjVy7ylqmfMBYaQkSs6pac0z6hBTvsgrH0r4FBYd/UYVJBmS6Rp/O+oCCQVLzKV1g=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="
     },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">= 0.4"
       }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1505,64 +1296,12 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/mkdirp": {
@@ -1577,9 +1316,10 @@
       }
     },
     "node_modules/module-details-from-path": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -1590,11 +1330,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-    },
-    "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/needle": {
       "version": "2.4.0",
@@ -1629,47 +1364,14 @@
       }
     },
     "node_modules/node-cron": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.2.tgz",
-      "integrity": "sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
       "dependencies": {
         "uuid": "8.3.2"
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/normalize-path": {
@@ -1678,17 +1380,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/nssocket": {
@@ -1707,22 +1398,6 @@
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ=="
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": {
-        "wrappy": "1"
-      }
     },
     "node_modules/pac-proxy-agent": {
       "version": "7.0.0",
@@ -1743,12 +1418,12 @@
       }
     },
     "node_modules/pac-resolver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
-      "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
-        "ip": "^1.1.8",
         "netmask": "^2.0.2"
       },
       "engines": {
@@ -1760,18 +1435,11 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1796,13 +1464,14 @@
       }
     },
     "node_modules/pm2": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pm2/-/pm2-5.3.0.tgz",
-      "integrity": "sha512-xscmQiAAf6ArVmKhjKTeeN8+Td7ZKnuZFFPw1DGkdFPR/0Iyx+m+1+OpCdf9+HQopX3VPc9/wqPQHqVOfHum9w==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/pm2/-/pm2-5.4.3.tgz",
+      "integrity": "sha512-4/I1htIHzZk1Y67UgOCo4F1cJtas1kSds31N8zN0PybO230id1nigyjGuGFzUnGmUFPmrJ0On22fO1ChFlp7VQ==",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@pm2/agent": "~2.0.0",
-        "@pm2/io": "~5.0.0",
-        "@pm2/js-api": "~0.6.7",
+        "@pm2/io": "~6.0.1",
+        "@pm2/js-api": "~0.8.0",
         "@pm2/pm2-version-check": "latest",
         "async": "~3.2.0",
         "blessed": "0.1.81",
@@ -1816,6 +1485,7 @@
         "enquirer": "2.3.6",
         "eventemitter2": "5.0.1",
         "fclone": "1.0.11",
+        "js-yaml": "~4.1.0",
         "mkdirp": "1.0.4",
         "needle": "2.4.0",
         "pidusage": "~3.0",
@@ -1827,8 +1497,7 @@
         "semver": "^7.2",
         "source-map-support": "0.5.21",
         "sprintf-js": "1.1.2",
-        "vizion": "~2.2.1",
-        "yamljs": "0.3.0"
+        "vizion": "~2.2.1"
       },
       "bin": {
         "pm2": "bin/pm2",
@@ -1837,7 +1506,7 @@
         "pm2-runtime": "bin/pm2-runtime"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12.0.0"
       },
       "optionalDependencies": {
         "pm2-sysmonit": "^1.2.8"
@@ -1967,19 +1636,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1991,16 +1647,11 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "peer": true
-    },
     "node_modules/require-in-the-middle": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
       "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -2011,16 +1662,20 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2030,20 +1685,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/run-series": {
       "version": "1.1.9",
@@ -2118,49 +1759,17 @@
         "node": ">=10"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
-    },
     "node_modules/shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -2172,15 +1781,16 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -2196,11 +1806,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/socks/node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -2237,46 +1842,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2292,6 +1857,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2300,9 +1866,10 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.18.12",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.18.12.tgz",
-      "integrity": "sha512-xXnT44zWVL7eADtbqQyEmAU/+nFQW1wl2DQ4d64E+zPicBwYV8lBcNmUYxGVEBC2EyGfSKinceal0eiHC8NJPw==",
+      "version": "5.30.7",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.30.7.tgz",
+      "integrity": "sha512-33B/cftpaWdpvH+Ho9U1b08ss8GQuLxrWHelbJT1yw4M48Taj8W3ezcPuaLoIHZz5V6tVHuQPr5BprEfnBLBMw==",
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin",
@@ -2325,26 +1892,11 @@
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
-    "node_modules/tar": {
-      "version": "6.1.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -2352,20 +1904,15 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/ts-mixer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
     "node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tv4": {
       "version": "1.3.0",
@@ -2385,15 +1932,17 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
-      "integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -2402,11 +1951,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -2438,42 +1982,10 @@
         "lodash": "^4.17.14"
       }
     },
-    "node_modules/weak-map": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
-      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2494,19 +2006,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "node_modules/yamljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
-      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
-      },
-      "bin": {
-        "json2yaml": "bin/json2yaml",
-        "yaml2json": "bin/yaml2json"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,20 @@
 {
+  "name": "daily-bible-verse-bot",
+  "version": "0.2.0",
+  "private": true,
+  "main": "js/bot.js",
+  "engines": {
+    "node": ">=22.5.0"
+  },
+  "scripts": {
+    "start": "node ./js/bot.js",
+    "test": "node --test --test-concurrency=1 \"test/*.test.js\""
+  },
   "dependencies": {
-    "axios": "^1.4.0",
-    "canvas": "^2.11.2",
-    "collections": "^5.1.13",
-    "date-fns-tz": "^2.0.0",
-    "discord.js": "^14.12.1",
+    "axios": "^1.13.5",
+    "discord.js": "^14.25.1",
     "log4js": "^6.9.1",
-    "node-cron": "^3.0.2",
-    "pm2": "^5.3.0"
+    "node-cron": "^3.0.3",
+    "pm2": "^5.4.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,112 +1,98 @@
 # Daily Bible Verse Bot
 
-The Daily Bible Verse Bot is a Discord bot that provides users with daily Bible verses, random verses, and more. It allows users to subscribe and unsubscribe from receiving daily verses and provides various statistics about its usage and activity.
-
-- [Daily Bible Verse Bot](#daily-bible-verse-bot)
-  - [If you wish to invite the bot to your server but do not want to run the bot yourself](#if-you-wish-to-invite-the-bot-to-your-server-but-do-not-want-to-run-the-bot-yourself)
-  - [Features](#features)
-  - [Installation](#installation)
-  - [Configuration](#configuration)
-  - [Usage](#usage)
-  - [Available Commands](#available-commands)
-  - [Directory Structure](#directory-structure)
-  - [Credits](#credits)
-  - [License](#license)
-
-
-## If you wish to invite the bot to your server but do not want to run the bot yourself
-- [Invite Link For Bot](https://discord.com/api/oauth2/authorize?client_id=1138224345446105108&permissions=380104993792&scope=applications.commands%20bot)
-- Join our [Development Discord Server](https://discord.gg/VquUZs2msF) to engage with the community.
+Daily Bible Verse Bot is a Discord bot that delivers daily verses, random verse requests, and server operations tooling for a production-style development workflow.
 
 ## Features
 
-- Get a daily Bible verse sent to your DM.
-- Receive a random Bible verse on demand.
-- Subscribe and unsubscribe from daily Bible verses.
-- View bot statistics, including subscribed users and command usage.
-- Customizable status messages.
-- Cross-server support.
+- Daily verse delivery to subscribed users.
+- Random verse delivery on-demand.
+- Per-user translation preferences.
+- Dev server bootstrap automation for roles/channels/overwrites/templates.
+- Ops commands for health, version, and release notes.
+- Structured bot error logging to `#bot-logs`.
 
 ## Installation
 
-1. Clone this repository to your local machine.
-2. Install the required dependencies using `npm install`.
+1. Clone this repository.
+2. Install dependencies:
+   - `npm install`
 
 ## Configuration
 
-1. Rename the `cfg/config.sample.json` file to `cfg/config.json`.
-2. Replace the `botToken` value in `config.json` with your Discord bot token.
+Copy `cfg/config-sample.json` to `cfg/config.json` and update values as needed.
+
+Environment variables are preferred for secrets and CI/CD deployments:
+
+- `BOT_TOKEN` (recommended, keep out of git)
+- `BIBLE_API_URL` (optional override)
+- `TRANSLATION_API_URL` (optional override)
+- `DEFAULT_TRANSLATION` (optional override)
+- `LOG_LEVEL` (optional override)
+- `GIT_SHA` or `COMMIT_SHA` (optional, used by `/version` and `/health`)
 
 ## Usage
 
-1. Run the bot using `node ./js/bot.js` or the provided `/scripts/pm2-startup.sh` script.
-2. Invite the bot to your Discord server using the provided invite link.
-3. Use the available slash commands to interact with the bot.
+- Start locally:
+  - `npm start`
+- Run tests:
+  - `npm test`
 
-## Available Commands
+## Slash Commands
 
-- `/subscribe`: Subscribe to receive daily Bible verses.
-- `/unsubscribe`: Unsubscribe from receiving daily Bible verses.
-- `/randomverse`: Get a random Bible verse via DM.
-- `/stats`: View bot statistics, including subscribed users and command usage.
-- `/support`: Get a link to the issue tracker for reporting issues and requesting support.
+- `/subscribe`
+- `/unsubscribe`
+- `/randomverse`
+- `/settranslation`
+- `/stats`
+- `/support`
+- `/health`
+- `/version`
+- `/release-notes` (Maintainer/Owner)
+- `/bootstrap-dev-server` (Maintainer/Owner)
 
-## Directory Structure
+## Discord Dev Server Setup
 
-daily-bible-verse-bot/
+Target dev guild:
+- `1471943418002280451`
 
-```
-│
-├── assets/
-│ ├── bible_scripture_icon.png
-│ └── statuses.txt
-│
-├── cfg/
-│ └── config.json
-│
-├── db/
-│ ├── subscribed_users.json
-│ └── stats.json
-│
-├── js/
-│ ├── commands/
-│ │ ├── subscribe.js
-│ │ ├── unsubscribe.js
-│ │ ├── randomverse.js
-│ │ ├── stats.js
-│ │ └── support.js
-│ ├── db/
-│ │ ├── subscribeDB.js
-│ │ └── statsDB.js
-│ ├── services/
-│ │ └── bibleApi.js
-│ ├── bot.js
-│ ├── logger.js
-│ └── verseSender.js
-│
-├── logs/
-│ ├── archive/
-│ │ ├── applicationExit_<timestamp>.log
-│ │ └── bot_<timestamp>.log
-│ ├── applicationExit.log
-│ └── bot.log
-│
-│ ├── archiveLog.sh
-│ ├── pm2-startup.sh
-│ └── pm2-stop.sh
-│
-├── package-lock.json
-├── package.json
-└── README.md
-```
+### OAuth Scopes
 
-## Credits
+- `bot`
+- `applications.commands`
 
-- [Bible.org Labs](https://labs.bible.org/)
-- [Discord.js](https://discord.js.org/)
-- [Node.js](https://nodejs.org/)
-- [Canvas](https://www.npmjs.com/package/canvas)
-- [node-cron](https://www.npmjs.com/package/node-cron)
+### Minimal Recommended Bot Permissions
+
+Grant only what is required for this project:
+
+- `View Channels`
+- `Send Messages`
+- `Embed Links`
+- `Attach Files`
+- `Read Message History`
+- `Use Slash Commands`
+- `Manage Channels` (bootstrap channel/category creation/repair)
+- `Manage Roles` (bootstrap role creation/overwrite repair)
+- `Manage Messages` (template pinning and status message updates)
+
+Avoid `Administrator` unless you explicitly need it for debugging.
+
+### How to Run Bootstrap
+
+1. Invite the bot with the scopes and permissions above.
+2. Run preview mode:
+   - `/bootstrap-dev-server dry_run:true`
+3. Apply changes:
+   - `/bootstrap-dev-server apply:true`
+4. Re-run preview to verify idempotency:
+   - `/bootstrap-dev-server dry_run:true`
+
+Detailed server spec is documented in `docs/discord-dev-server.md`.
+
+## Development Notes
+
+- Admin/ops commands are restricted to guild owner or `Maintainer` role.
+- Operational logs are written to `#bot-logs` when available.
+- Status heartbeat can be maintained in `#bot-status`.
 
 ## License
 

--- a/test/botOps.test.js
+++ b/test/botOps.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildBootstrapSummaryMessage,
+  truncateText,
+} = require('../js/services/botOps.js');
+
+test('truncateText keeps short strings and truncates long strings', () => {
+  assert.equal(truncateText('abc', 10), 'abc');
+  assert.equal(truncateText('0123456789', 6), '012...');
+});
+
+test('buildBootstrapSummaryMessage includes counts and sections', () => {
+  const report = {
+    created: ['Role: Maintainer'],
+    updated: ['Overwrite: @everyone on #welcome'],
+    unchanged: ['Channel exists: #welcome'],
+    warnings: ['Missing channel #bot-logs'],
+  };
+
+  const output = buildBootstrapSummaryMessage('dry-run', report);
+  assert.match(output, /DRY-RUN summary/i);
+  assert.match(output, /Created: 1/);
+  assert.match(output, /Updated: 1/);
+  assert.match(output, /Warnings: 1/);
+  assert.match(output, /Role: Maintainer/);
+});

--- a/test/databaseMigration.test.js
+++ b/test/databaseMigration.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  cleanupSandbox,
+  createTempDatabaseSandbox,
+  loadDbModulesForSandbox,
+} = require('./helpers/dbTestUtils.js');
+
+test('database initialization migrates legacy JSON subscription and stats files', async () => {
+  const sandbox = createTempDatabaseSandbox();
+
+  const legacySubscriptions = [
+    { id: 'legacy-user-1' },
+    { id: 'legacy-user-2', translation: 'kjv' },
+  ];
+  const legacyStats = {
+    totalVersesSent: 7,
+    totalCommandsExecuted: 9,
+    activeGuilds: 2,
+  };
+
+  fs.writeFileSync(
+    path.join(sandbox.legacyDir, 'subscribed_users.json'),
+    JSON.stringify(legacySubscriptions, null, 2),
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(sandbox.legacyDir, 'stats.json'),
+    JSON.stringify(legacyStats, null, 2),
+    'utf8'
+  );
+
+  const { database, subscribeDB, statsDB } = loadDbModulesForSandbox(sandbox);
+
+  try {
+    const subscribedUsers = await subscribeDB.getSubscribedUsers();
+    assert.equal(subscribedUsers.length, 2);
+
+    const firstUser = subscribedUsers.find((user) => user.id === 'legacy-user-1');
+    const secondUser = subscribedUsers.find((user) => user.id === 'legacy-user-2');
+    assert.deepEqual(firstUser, { id: 'legacy-user-1', translation: 'web' });
+    assert.deepEqual(secondUser, { id: 'legacy-user-2', translation: 'kjv' });
+
+    const stats = await statsDB.getStats();
+    assert.equal(stats.totalVersesSent, 7);
+    assert.equal(stats.totalCommandsExecuted, 9);
+    assert.equal(stats.activeGuilds, 2);
+  } finally {
+    await cleanupSandbox(sandbox, database);
+  }
+});

--- a/test/helpers/dbTestUtils.js
+++ b/test/helpers/dbTestUtils.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const PROJECT_MODULES = [
+  '../../js/db/database.js',
+  '../../js/db/subscribeDB.js',
+  '../../js/db/statsDB.js',
+];
+
+function createTempDatabaseSandbox() {
+  const rootDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'daily-bible-verse-bot-test-')
+  );
+  const dbPath = path.join(rootDir, 'bot.sqlite');
+  const legacyDir = path.join(rootDir, 'legacy');
+  fs.mkdirSync(legacyDir, { recursive: true });
+
+  return {
+    rootDir,
+    dbPath,
+    legacyDir,
+  };
+}
+
+function clearProjectModuleCache() {
+  for (const modulePath of PROJECT_MODULES) {
+    try {
+      delete require.cache[require.resolve(modulePath)];
+    } catch (error) {
+      // Ignore modules that are not in cache yet.
+    }
+  }
+}
+
+function loadDbModulesForSandbox(sandbox) {
+  process.env.DB_PATH = sandbox.dbPath;
+  process.env.LEGACY_DB_DIR = sandbox.legacyDir;
+  clearProjectModuleCache();
+
+  const database = require('../../js/db/database.js');
+  const subscribeDB = require('../../js/db/subscribeDB.js');
+  const statsDB = require('../../js/db/statsDB.js');
+
+  return {
+    database,
+    subscribeDB,
+    statsDB,
+  };
+}
+
+async function cleanupSandbox(sandbox, database) {
+  if (database && typeof database.closeDatabase === 'function') {
+    await database.closeDatabase();
+  }
+
+  delete process.env.DB_PATH;
+  delete process.env.LEGACY_DB_DIR;
+  clearProjectModuleCache();
+
+  fs.rmSync(sandbox.rootDir, { recursive: true, force: true });
+}
+
+module.exports = {
+  cleanupSandbox,
+  createTempDatabaseSandbox,
+  loadDbModulesForSandbox,
+};

--- a/test/permissionUtils.test.js
+++ b/test/permissionUtils.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  isOwnerOrMaintainer,
+  memberHasRoleByName,
+} = require('../js/services/permissionUtils.js');
+
+function buildMemberWithRoles(roleNames) {
+  const roles = roleNames.map((name) => ({ name }));
+  return {
+    roles: {
+      cache: {
+        some: (predicate) => roles.some(predicate),
+      },
+    },
+  };
+}
+
+test('memberHasRoleByName resolves case-insensitive role names', () => {
+  const member = buildMemberWithRoles(['Contributor', 'Maintainer']);
+  assert.equal(memberHasRoleByName(member, 'maintainer'), true);
+  assert.equal(memberHasRoleByName(member, 'reviewer'), false);
+});
+
+test('isOwnerOrMaintainer grants owner access', () => {
+  const interaction = {
+    guild: { ownerId: 'owner-123' },
+    user: { id: 'owner-123' },
+    member: buildMemberWithRoles([]),
+  };
+
+  assert.equal(isOwnerOrMaintainer(interaction), true);
+});
+
+test('isOwnerOrMaintainer grants Maintainer role access', () => {
+  const interaction = {
+    guild: { ownerId: 'owner-123' },
+    user: { id: 'member-1' },
+    member: buildMemberWithRoles(['maintainer']),
+  };
+
+  assert.equal(isOwnerOrMaintainer(interaction), true);
+});
+
+test('isOwnerOrMaintainer denies non-owner non-maintainer access', () => {
+  const interaction = {
+    guild: { ownerId: 'owner-123' },
+    user: { id: 'member-1' },
+    member: buildMemberWithRoles(['Contributor']),
+  };
+
+  assert.equal(isOwnerOrMaintainer(interaction), false);
+});

--- a/test/statsDB.test.js
+++ b/test/statsDB.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  cleanupSandbox,
+  createTempDatabaseSandbox,
+  loadDbModulesForSandbox,
+} = require('./helpers/dbTestUtils.js');
+
+test('statsDB tracks counts and derives subscribed users from subscriptions', async () => {
+  const sandbox = createTempDatabaseSandbox();
+  const { database, subscribeDB, statsDB } = loadDbModulesForSandbox(sandbox);
+
+  try {
+    await subscribeDB.addSubscribedUser('user-1', 'web');
+    await subscribeDB.addSubscribedUser('user-2', 'kjv');
+
+    await statsDB.addVerseSent();
+    await statsDB.addVerseSent();
+    await statsDB.addCommandExecution();
+    await statsDB.updateActiveGuilds({ guilds: { cache: { size: 3 } } });
+
+    const stats = await statsDB.getStats();
+    assert.equal(stats.subscribedUsersCount, 2);
+    assert.equal(stats.totalVersesSent, 2);
+    assert.equal(stats.totalCommandsExecuted, 1);
+    assert.equal(stats.activeGuilds, 3);
+  } finally {
+    await cleanupSandbox(sandbox, database);
+  }
+});

--- a/test/subscribeDB.test.js
+++ b/test/subscribeDB.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  cleanupSandbox,
+  createTempDatabaseSandbox,
+  loadDbModulesForSandbox,
+} = require('./helpers/dbTestUtils.js');
+
+test('subscribeDB stores subscriptions and translation preferences', async () => {
+  const sandbox = createTempDatabaseSandbox();
+  const { database, subscribeDB } = loadDbModulesForSandbox(sandbox);
+
+  try {
+    await subscribeDB.addSubscribedUser('user-1', 'kjv');
+    await subscribeDB.addSubscribedUser('user-2', 'darby');
+
+    const subscribedUsers = await subscribeDB.getSubscribedUsers();
+    assert.equal(subscribedUsers.length, 2);
+    assert.deepEqual(subscribedUsers[0], { id: 'user-1', translation: 'kjv' });
+    assert.deepEqual(subscribedUsers[1], { id: 'user-2', translation: 'darby' });
+
+    assert.equal(await subscribeDB.isSubscribed('user-1'), true);
+    assert.equal(await subscribeDB.isSubscribed('user-3'), false);
+
+    await subscribeDB.setUserTranslation('user-1', 'webbe');
+    const preferences = await subscribeDB.getUserPreferences('user-1');
+    assert.deepEqual(preferences, { id: 'user-1', translation: 'webbe' });
+  } finally {
+    await cleanupSandbox(sandbox, database);
+  }
+});
+
+test('subscribeDB removal operations are consistent', async () => {
+  const sandbox = createTempDatabaseSandbox();
+  const { database, subscribeDB } = loadDbModulesForSandbox(sandbox);
+
+  try {
+    await subscribeDB.addSubscribedUser('user-1', 'web');
+    await subscribeDB.addSubscribedUser('user-2', 'kjv');
+
+    await subscribeDB.removeSubscribedUser('user-1');
+    assert.equal(await subscribeDB.isSubscribed('user-1'), false);
+    assert.equal(await subscribeDB.isSubscribed('user-2'), true);
+
+    await subscribeDB.removeAllSubscribedUsers();
+    const subscribedUsers = await subscribeDB.getSubscribedUsers();
+    assert.deepEqual(subscribedUsers, []);
+  } finally {
+    await cleanupSandbox(sandbox, database);
+  }
+});


### PR DESCRIPTION
## Summary
- Add idempotent `/bootstrap-dev-server` command for the target guild (`1471943418002280451`).
- Define and automate dev server categories/channels/roles/permission overwrites.
- Enforce owner or `Maintainer` role for admin commands (`/bootstrap-dev-server`, `/release-notes`).
- Add pinned template upsert for `#welcome`, `#qa-testing`, and `#design-decisions`.
- Add `/health`, `/version`, `/release-notes` commands and periodic non-spam `#bot-status` updates.
- Add structured bot error/runtime logging pipeline to `#bot-logs`.
- Document server spec in `docs/discord-dev-server.md` and update README setup/runbook.
- Include focused tests for permissions, bot ops formatting, and persistence/migration.

## Validation
- `npm test`
- `node --check` on JS source files
- Local command module load check

## Manual verification in target guild
1. Run `/bootstrap-dev-server dry_run:true`.
2. Run `/bootstrap-dev-server apply:true`.
3. Re-run `/bootstrap-dev-server dry_run:true` and confirm minimal/no diffs.
4. Confirm `#bot-logs` receives bootstrap summary and error logs.
5. Confirm pinned templates in `#welcome`, `#qa-testing`, and `#design-decisions`.
6. Run `/health`, `/version`, and `/release-notes`.