### PR TITLE
fix: scope canary deploy concurrency to branch

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -11,9 +11,9 @@ permissions:
   contents: read
 
 concurrency:
-  # Avoid cross-branch cancellations while master still contains a legacy workflow_run-based canary deploy.
-  # This should always be branch-scoped anyway: we only want one canary deploy at a time per branch.
-  group: deploy-canary-${{ github.ref }}
+  # Serialize all canary deployments (shared EC2 target), but avoid collisions with the legacy
+  # default-branch workflow which also uses the `deploy-canary` concurrency group.
+  group: deploy-canary-v2
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Prevent canary deploy runs from being cancelled by legacy default-branch workflow runs by using a dedicated concurrency group (`deploy-canary-v2`).

## Testing
- Not applicable (workflow-only change).

## Copilot Review Gate
- [x] Copilot review requested / automatic review confirmed enabled (auto-review by `copilot-pull-request-reviewer`)
- [x] Copilot review comments received (1 thread)
- [x] Every Copilot comment fixed OR replied-to with justification
- [x] CI is green (tests/lint)
- [x] Deployment-impact changes documented
