### PR TITLE
promote: canary -> master (logging/status/paging consistency)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,8 +71,21 @@ jobs:
 
           asset_name="${{ steps.meta.outputs.asset_name }}"
 
+          mkdir -p build
+          built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          cat > build/version.json <<EOF
+          {
+            "tag": "${{ steps.meta.outputs.release_tag }}",
+            "sha": "${GITHUB_SHA}",
+            "builtAt": "${built_at}",
+            "runId": "${GITHUB_RUN_ID}",
+            "runNumber": "${GITHUB_RUN_NUMBER}"
+          }
+          EOF
+
           # Keep the artifact small and deterministic.
           tar -czf "${asset_name}" \
+            build/version.json \
             Dockerfile \
             docker-compose.prod.yml \
             package.json \

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,12 @@ services:
       NODE_ENV: production
       GIT_SHA: ${GIT_SHA:-unknown}
       DEPLOY_ENVIRONMENT: ${DEPLOY_ENVIRONMENT:-unknown}
+      RELEASE_TAG: ${RELEASE_TAG:-unknown}
+      BUILD_TIME: ${BUILD_TIME:-unknown}
+      DEPLOYED_AT: ${DEPLOYED_AT:-unknown}
+      DEV_LOGGING_ENABLED: ${DEV_LOGGING_ENABLED:-}
+      DEV_GUILD_ID: ${DEV_GUILD_ID:-}
+      DEV_BOT_LOGS_CHANNEL_ID: ${DEV_BOT_LOGS_CHANNEL_ID:-}
       BOT_TOKEN: ${BOT_TOKEN:?BOT_TOKEN must be provided by deployment pipeline}
     volumes:
       - ../db:/app/db

--- a/js/commands/passage.js
+++ b/js/commands/passage.js
@@ -7,14 +7,8 @@ const { parseScriptureReference } = require('../services/scriptureReference.js')
 const { paginateLines } = require('../services/pagination.js');
 const { createPaginatedMessage } = require('../services/paginationInteractions.js');
 const { buildEmbedTitle, formatPassageLines } = require('../services/passageFormatter.js');
+const { buildScriptureFooter, buildStandardEmbed, COLORS } = require('../services/messageStyle.js');
 const { logCommandError } = require('../services/botOps.js');
-
-function buildFooter(passage) {
-  const translationName = String(passage.translationName || 'World English Bible').trim();
-  const note = String(passage.translationNote || '').trim();
-  const noteSuffix = note ? ` • ${note}` : '';
-  return `${translationName}${noteSuffix} • Source: bible-api.com`;
-}
 
 function buildEmbed(session, timestamp = new Date()) {
   // createPaginatedMessage returns an embed without a timestamp. We add it here so the
@@ -74,8 +68,8 @@ module.exports = {
         userId: interaction.user.id,
         pages,
         title,
-        color: '#0099ff',
-        footer: buildFooter(passage),
+        color: COLORS.primary,
+        footer: buildScriptureFooter(passage),
         ttlMs: 25 * 60 * 1000,
       });
 
@@ -85,12 +79,13 @@ module.exports = {
       };
 
       if (mode === 'dm') {
-        const notice = interaction.guildId
-          ? 'Check your DMs.'
-          : null;
-
-        if (notice) {
-          await interaction.reply({ content: notice, ephemeral: true });
+        if (interaction.guildId) {
+          const embed = buildStandardEmbed({
+            title: 'Check your DMs',
+            description: 'I sent you the passage with pagination controls.',
+            color: COLORS.primary,
+          });
+          await interaction.reply({ embeds: [embed], ephemeral: true });
         } else {
           await interaction.reply(payload);
         }

--- a/js/commands/randomVerse.js
+++ b/js/commands/randomVerse.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 const sendDailyVerse = require('../verseSender');
 const { logger } = require('../logger.js');
 const { addCommandExecution } = require('../db/statsDB.js');
@@ -10,6 +10,7 @@ const {
   toDiscordChoices,
 } = require('../constants/translations.js');
 const { logCommandError } = require('../services/botOps.js');
+const { buildStandardEmbed, COLORS } = require('../services/messageStyle.js');
 
 const translationChoices = toDiscordChoices().slice(0, 25);
 
@@ -38,15 +39,12 @@ module.exports = {
       );
       const translationLabel = getTranslationLabel(selectedTranslation);
 
-      const embed = new EmbedBuilder()
-        .setTitle('A random Bible verse has been sent to your DMs')
-        .setColor('#0099FF')
-        .setTimestamp()
-        .setDescription(`Translation: ${translationLabel}.`)
-        .setFooter({
-          text: 'Use /settranslation to change your saved preference.',
-        })
-        .setThumbnail(interaction.client.user.displayAvatarURL());
+      const embed = buildStandardEmbed({
+        title: 'Check your DMs',
+        color: COLORS.primary,
+        description: `I sent you a random verse. Translation: ${translationLabel}.`,
+        footerText: 'Use /settranslation to change your saved preference.',
+      });
       await interaction.reply({ embeds: [embed], ephemeral: true });
 
       const didSend = await sendDailyVerse(interaction.client, interaction.user.id, 'random', {

--- a/js/commands/read.js
+++ b/js/commands/read.js
@@ -1,9 +1,10 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 const { addCommandExecution } = require('../db/statsDB.js');
 const { logger } = require('../logger.js');
 const { buildReadMessage, createReadSession } = require('../services/readSessions.js');
 const { logCommandError } = require('../services/botOps.js');
+const { buildStandardEmbed, COLORS } = require('../services/messageStyle.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -31,11 +32,12 @@ module.exports = {
       const payload = buildReadMessage(session);
 
       if (interaction.guildId) {
-        const embed = new EmbedBuilder()
-          .setTitle('Check your DMs')
-          .setDescription('I sent you a page-turner reader session.')
-          .setColor('#0099ff')
-          .setTimestamp();
+        const embed = buildStandardEmbed({
+          title: 'Check your DMs',
+          description: 'I sent you a page-turner reader session.',
+          color: COLORS.primary,
+          footerText: 'Use /read again to jump to a new reference.',
+        });
 
         await interaction.reply({ embeds: [embed], ephemeral: true });
         await interaction.user.send(payload);

--- a/js/commands/stats.js
+++ b/js/commands/stats.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { getStats, addCommandExecution } = require('../db/statsDB.js');
-const { version } = require('../config.js');
+const { getBuildInfo } = require('../services/buildInfo.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -10,6 +10,7 @@ module.exports = {
     await addCommandExecution();
 
     const stats = await getStats();
+    const buildInfo = getBuildInfo();
     const uptime = interaction.client.uptime || 0;
 
     const days = Math.floor(uptime / 86400000);
@@ -31,7 +32,8 @@ module.exports = {
         },
         { name: 'Total Active Guilds', value: String(stats.activeGuilds), inline: true },
         { name: 'Uptime', value: `${days}d ${hours}h ${minutes}m ${seconds}s`, inline: true },
-        { name: 'Bot Version', value: version, inline: true }
+        { name: 'Release Tag', value: buildInfo.releaseTag, inline: true },
+        { name: 'Git SHA', value: buildInfo.gitSha, inline: true }
       )
       .setThumbnail(interaction.client.user.displayAvatarURL());
 

--- a/js/commands/status.js
+++ b/js/commands/status.js
@@ -1,0 +1,25 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+const { addCommandExecution } = require('../db/statsDB.js');
+const { requireOwnerOrMaintainer } = require('../services/permissionUtils.js');
+const { buildHealthEmbed } = require('../services/botOps.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('status')
+    .setDescription('Show detailed bot status (maintainers only)'),
+  async execute(interaction) {
+    await addCommandExecution();
+
+    const authorized = await requireOwnerOrMaintainer(interaction);
+    if (!authorized) {
+      return;
+    }
+
+    await interaction.reply({
+      embeds: [buildHealthEmbed(interaction.client)],
+      ephemeral: true,
+    });
+  },
+};
+

--- a/js/commands/support.js
+++ b/js/commands/support.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const { issueTrackerUrl, version } = require('../config.js');
+const { issueTrackerUrl } = require('../config.js');
 const { addCommandExecution } = require('../db/statsDB.js');
+const { getBuildInfo } = require('../services/buildInfo.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -8,6 +9,7 @@ module.exports = {
     .setDescription('Get support and report issues'),
   async execute(interaction) {
     await addCommandExecution();
+    const buildInfo = getBuildInfo();
 
     const supportEmbed = new EmbedBuilder()
       .setTitle('Need Support or Found a Bug?')
@@ -16,7 +18,7 @@ module.exports = {
       .setDescription(
         `If you need support, found a bug, or want to make a feature request, please open an issue at: ${issueTrackerUrl}`
       )
-      .setFooter({ text: `Bot Version: ${version}` })
+      .setFooter({ text: `Bot: ${buildInfo.releaseTag} (${buildInfo.gitSha})` })
       .setThumbnail(interaction.client.user.displayAvatarURL());
 
     await interaction.reply({ embeds: [supportEmbed], ephemeral: true });

--- a/js/commands/version.js
+++ b/js/commands/version.js
@@ -1,22 +1,39 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { addCommandExecution } = require('../db/statsDB.js');
 const { getBuildInfo } = require('../services/buildInfo.js');
+const { formatDiscordTimestamp } = require('../services/discordFormat.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('version')
-    .setDescription('Show bot semantic version and git SHA'),
+    .setDescription('Show bot version metadata (tag, SHA, build/deploy time)'),
   async execute(interaction) {
     await addCommandExecution();
-    const { version, gitSha } = getBuildInfo();
+    const buildInfo = getBuildInfo();
 
     const embed = new EmbedBuilder()
       .setTitle('Build Version')
       .setColor('#2980b9')
       .setTimestamp()
       .addFields(
-        { name: 'Version', value: version, inline: true },
-        { name: 'Git SHA', value: gitSha, inline: true }
+        { name: 'Release Tag', value: buildInfo.releaseTag, inline: true },
+        { name: 'Package Version', value: buildInfo.packageVersion, inline: true },
+        { name: 'Git SHA', value: buildInfo.gitSha, inline: true },
+        {
+          name: 'Environment',
+          value: buildInfo.runtimeEnvironment,
+          inline: true,
+        },
+        {
+          name: 'Built At',
+          value: formatDiscordTimestamp(buildInfo.builtAt),
+          inline: true,
+        },
+        {
+          name: 'Deployed At',
+          value: formatDiscordTimestamp(buildInfo.deployedAt),
+          inline: true,
+        }
       );
 
     await interaction.reply({ embeds: [embed], ephemeral: true });

--- a/js/services/correlation.js
+++ b/js/services/correlation.js
@@ -1,0 +1,33 @@
+const crypto = require('node:crypto');
+const { AsyncLocalStorage } = require('node:async_hooks');
+
+const storage = new AsyncLocalStorage();
+
+function generateCorrelationId() {
+  try {
+    if (typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // ignore
+  }
+
+  return crypto.randomBytes(16).toString('hex');
+}
+
+function runWithCorrelationId(correlationId, fn) {
+  const id = String(correlationId || '').trim() || generateCorrelationId();
+  return storage.run({ correlationId: id }, fn);
+}
+
+function getCorrelationId() {
+  const store = storage.getStore();
+  return store?.correlationId || null;
+}
+
+module.exports = {
+  generateCorrelationId,
+  getCorrelationId,
+  runWithCorrelationId,
+};
+

--- a/js/services/devBotLogs.js
+++ b/js/services/devBotLogs.js
@@ -1,0 +1,535 @@
+const {
+  ChannelType,
+} = require('discord.js');
+
+const { logger } = require('../logger.js');
+const { TARGET_DEV_GUILD_ID, CHANNEL_NAMES } = require('../constants/devServerSpec.js');
+const { getBuildInfo } = require('./buildInfo.js');
+const { getCorrelationId } = require('./correlation.js');
+
+const LEVELS = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+function parseBoolean(value, defaultValue) {
+  if (value == null || String(value).trim().length === 0) {
+    return defaultValue;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+    return true;
+  }
+  if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+    return false;
+  }
+
+  return defaultValue;
+}
+
+function parsePositiveInt(value, defaultValue) {
+  if (value == null || String(value).trim().length === 0) {
+    return defaultValue;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+  return Math.floor(parsed);
+}
+
+function parseLogLevel(value, defaultLevel) {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (Object.prototype.hasOwnProperty.call(LEVELS, normalized)) {
+    return normalized;
+  }
+  return defaultLevel;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sanitizeValue(value) {
+  if (value == null) {
+    return '';
+  }
+
+  return String(value)
+    .replace(/\r/g, '')
+    .replace(/\n/g, '\\n')
+    .slice(0, 500);
+}
+
+function toIso(value) {
+  try {
+    return new Date(value || Date.now()).toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+function buildConfig(environment = process.env) {
+  const runtimeEnvironment = String(
+    environment.DEPLOY_ENVIRONMENT || environment.APP_ENV || environment.NODE_ENV || ''
+  )
+    .trim()
+    .toLowerCase();
+
+  const enabledDefault = runtimeEnvironment === 'canary';
+  const enabled = parseBoolean(environment.DEV_LOGGING_ENABLED, enabledDefault);
+
+  const defaultLevel = runtimeEnvironment === 'production' ? 'warn' : 'info';
+  const level = parseLogLevel(environment.DEV_LOG_LEVEL, defaultLevel);
+
+  return {
+    enabled,
+    level,
+    guildId: String(environment.DEV_GUILD_ID || TARGET_DEV_GUILD_ID).trim() || TARGET_DEV_GUILD_ID,
+    channelId: String(environment.DEV_BOT_LOGS_CHANNEL_ID || '').trim() || null,
+    flushIntervalMs: parsePositiveInt(environment.DEV_LOG_FLUSH_INTERVAL_MS, 2000),
+    maxBatchItems: parsePositiveInt(environment.DEV_LOG_MAX_BATCH_ITEMS, 20),
+    maxQueueItems: parsePositiveInt(environment.DEV_LOG_MAX_QUEUE_ITEMS, 500),
+    // Leave headroom for code fences and Discord formatting.
+    maxMessageChars: 1900,
+    // Coalesce repeated identical events to avoid log spam loops.
+    coalesceWindowMs: parsePositiveInt(environment.DEV_LOG_COALESCE_WINDOW_MS, 15_000),
+    startupRetryAttempts: parsePositiveInt(environment.DEV_LOG_STARTUP_RETRY_ATTEMPTS, 5),
+  };
+}
+
+function shouldPost(level, config) {
+  const incoming = LEVELS[String(level || '').toLowerCase()] ?? LEVELS.info;
+  const threshold = LEVELS[config.level] ?? LEVELS.info;
+  return incoming >= threshold;
+}
+
+const state = {
+  client: null,
+  config: buildConfig(),
+  startedAtMs: Date.now(),
+  queue: [],
+  flushTimer: null,
+  stopped: false,
+  resolvingChannel: null,
+  cachedChannel: null,
+  // Health / circuit breaker
+  lastSuccessAtMs: 0,
+  lastFailureAtMs: 0,
+  consecutiveFailures: 0,
+  disabledUntilMs: 0,
+  droppedCount: 0,
+  lastWarningAtMs: 0,
+  // Coalescing
+  lastEnqueuedKey: null,
+  lastEnqueuedAtMs: 0,
+};
+
+async function resolveLogsChannel() {
+  if (state.cachedChannel) {
+    return state.cachedChannel;
+  }
+
+  if (!state.client) {
+    return null;
+  }
+
+  if (state.resolvingChannel) {
+    return state.resolvingChannel;
+  }
+
+  state.resolvingChannel = (async () => {
+    const client = state.client;
+    const { guildId, channelId } = state.config;
+
+    if (channelId) {
+      const direct = await client.channels.fetch(channelId).catch(() => null);
+      if (direct && typeof direct.send === 'function') {
+        state.cachedChannel = direct;
+        state.resolvingChannel = null;
+        return direct;
+      }
+    }
+
+    const guild = client.guilds.cache.get(guildId) || (await client.guilds.fetch(guildId).catch(() => null));
+    if (!guild) {
+      state.resolvingChannel = null;
+      return null;
+    }
+
+    // Ensure the channel cache is populated.
+    if (typeof guild.channels.fetch === 'function') {
+      await guild.channels.fetch().catch(() => null);
+    }
+
+    const channel =
+      guild.channels.cache.find(
+        (candidate) =>
+          candidate &&
+          candidate.type === ChannelType.GuildText &&
+          String(candidate.name || '').toLowerCase() === CHANNEL_NAMES.botLogs
+      ) || null;
+
+    state.cachedChannel = channel;
+    state.resolvingChannel = null;
+    return channel;
+  })();
+
+  return state.resolvingChannel;
+}
+
+function formatEntry(entry) {
+  const parts = [];
+  parts.push(`${entry.timestamp} [${entry.level.toUpperCase()}] ${entry.event}`);
+
+  if (entry.correlationId) {
+    parts.push(`cid=${sanitizeValue(entry.correlationId)}`);
+  }
+
+  if (entry.message) {
+    parts.push(`msg=${sanitizeValue(entry.message)}`);
+  }
+
+  const fields = entry.fields && typeof entry.fields === 'object' ? entry.fields : null;
+  if (fields) {
+    const keys = Object.keys(fields).sort();
+    for (const key of keys) {
+      const value = fields[key];
+      if (value == null) {
+        continue;
+      }
+      parts.push(`${key}=${sanitizeValue(value)}`);
+    }
+  }
+
+  if (entry.count && entry.count > 1) {
+    parts.push(`x${entry.count}`);
+  }
+
+  return parts.join(' ');
+}
+
+function formatDiscordMessage(lines) {
+  const body = lines.join('\n');
+  return `\`\`\`log\n${body}\n\`\`\``;
+}
+
+function logStructuredToStdout(entry) {
+  try {
+    // This is intentionally JSON so it can be grepped/queried from container logs.
+    const payload = {
+      ts: entry.timestamp,
+      level: entry.level,
+      event: entry.event,
+      cid: entry.correlationId || undefined,
+      msg: entry.message || undefined,
+      fields: entry.fields || undefined,
+      count: entry.count || undefined,
+    };
+
+    if (entry.level === 'error') {
+      logger.error(JSON.stringify(payload));
+    } else if (entry.level === 'warn') {
+      logger.warn(JSON.stringify(payload));
+    } else if (entry.level === 'debug') {
+      logger.debug(JSON.stringify(payload));
+    } else {
+      logger.info(JSON.stringify(payload));
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function enqueue(entry) {
+  if (state.stopped) {
+    return;
+  }
+
+  if (!state.config.enabled) {
+    return;
+  }
+
+  if (!shouldPost(entry.level, state.config)) {
+    return;
+  }
+
+  logStructuredToStdout(entry);
+
+  const now = Date.now();
+  if (state.disabledUntilMs > now) {
+    state.droppedCount += 1;
+    return;
+  }
+
+  if (state.queue.length >= state.config.maxQueueItems) {
+    state.droppedCount += 1;
+    state.queue.shift();
+  }
+
+  const key = `${entry.level}|${entry.event}|${entry.message || ''}`;
+  const canCoalesce = entry.level === 'warn' || entry.level === 'error';
+  if (
+    canCoalesce &&
+    state.queue.length > 0 &&
+    state.lastEnqueuedKey === key &&
+    now - state.lastEnqueuedAtMs <= state.config.coalesceWindowMs
+  ) {
+    const last = state.queue[state.queue.length - 1];
+    if (last && last.__coalesceKey === key) {
+      last.count = (last.count || 1) + 1;
+      last.timestamp = entry.timestamp;
+      state.lastEnqueuedAtMs = now;
+      return;
+    }
+  }
+
+  entry.__coalesceKey = key;
+  entry.count = entry.count || 1;
+  state.queue.push(entry);
+  state.lastEnqueuedKey = key;
+  state.lastEnqueuedAtMs = now;
+
+  if (state.queue.length >= state.config.maxBatchItems) {
+    // Fire-and-forget flush.
+    flush().catch(() => null);
+  }
+}
+
+async function sendToDiscord(content) {
+  const channel = await resolveLogsChannel();
+  if (!channel) {
+    throw new Error('Dev #bot-logs channel not found or not accessible.');
+  }
+
+  await channel.send({ content });
+}
+
+function registerFailure(error) {
+  const now = Date.now();
+  state.lastFailureAtMs = now;
+  state.consecutiveFailures += 1;
+
+  if (state.consecutiveFailures >= 3) {
+    const exponent = Math.min(6, state.consecutiveFailures - 3);
+    const cooldownMs = Math.min(30 * 60_000, 60_000 * 2 ** exponent);
+    state.disabledUntilMs = now + cooldownMs;
+  }
+
+  // Throttle warning spam to local logs.
+  if (now - state.lastWarningAtMs > 60_000) {
+    state.lastWarningAtMs = now;
+    const until = state.disabledUntilMs > now
+      ? `; circuit open for ${Math.round((state.disabledUntilMs - now) / 1000)}s`
+      : '';
+    logger.warn(
+      `Failed to post to dev #bot-logs (${state.consecutiveFailures} consecutive failures)${until}: ${error?.message || error}`
+    );
+  }
+}
+
+function registerSuccess() {
+  state.lastSuccessAtMs = Date.now();
+  state.consecutiveFailures = 0;
+  state.disabledUntilMs = 0;
+}
+
+async function flush() {
+  if (state.stopped) {
+    return;
+  }
+
+  if (!state.config.enabled) {
+    return;
+  }
+
+  const now = Date.now();
+  if (state.disabledUntilMs > now) {
+    return;
+  }
+
+  if (state.queue.length === 0) {
+    return;
+  }
+
+  // Drain a bounded batch and send it as 1..N discord messages under the 2000 char limit.
+  const batch = state.queue.splice(0, state.config.maxBatchItems);
+  const chunks = [];
+  let current = { lines: [], entries: [] };
+
+  const pushChunk = () => {
+    if (current.entries.length === 0) {
+      return;
+    }
+    chunks.push(current);
+    current = { lines: [], entries: [] };
+  };
+
+  for (const entry of batch) {
+    const line = formatEntry(entry);
+    const nextLines = current.lines.concat(line);
+    const nextMessage = formatDiscordMessage(nextLines);
+
+    if (nextMessage.length > state.config.maxMessageChars) {
+      pushChunk();
+
+      const single = formatDiscordMessage([line]);
+      if (single.length > state.config.maxMessageChars) {
+        // Extremely defensive: truncate line content if it still won't fit.
+        const clipped = line.slice(0, Math.max(0, state.config.maxMessageChars - 50)) + '...';
+        chunks.push({ lines: [clipped], entries: [entry] });
+      } else {
+        current = { lines: [line], entries: [entry] };
+      }
+      continue;
+    }
+
+    current.lines = nextLines;
+    current.entries.push(entry);
+  }
+
+  pushChunk();
+
+  for (let i = 0; i < chunks.length; i += 1) {
+    const chunk = chunks[i];
+    try {
+      await sendToDiscord(formatDiscordMessage(chunk.lines));
+    } catch (error) {
+      // Requeue only the entries that were not sent yet. Entries in earlier chunks were
+      // already posted successfully and should not be duplicated.
+      const unsent = [];
+      for (let j = i; j < chunks.length; j += 1) {
+        unsent.push(...chunks[j].entries);
+      }
+      state.queue.unshift(...unsent);
+      registerFailure(error);
+      return;
+    }
+  }
+
+  registerSuccess();
+}
+
+function start(client, options = {}) {
+  state.client = client;
+  state.config = {
+    ...buildConfig(),
+    ...(options.config || {}),
+  };
+
+  state.stopped = false;
+  state.startedAtMs = Date.now();
+  state.cachedChannel = null;
+  state.resolvingChannel = null;
+
+  if (!state.config.enabled) {
+    logger.info('Dev #bot-logs is disabled (DEV_LOGGING_ENABLED=false).');
+    return;
+  }
+
+  if (state.flushTimer) {
+    clearInterval(state.flushTimer);
+  }
+
+  state.flushTimer = setInterval(() => {
+    flush().catch(() => null);
+  }, state.config.flushIntervalMs);
+  state.flushTimer.unref?.();
+}
+
+async function validateStartup() {
+  if (!state.config.enabled) {
+    return { ok: false, reason: 'disabled' };
+  }
+
+  const build = getBuildInfo();
+  const baseMessage = `✅ Bot started env=${build.runtimeEnvironment} tag=${build.releaseTag} sha=${build.gitSha}`;
+
+  let lastError = null;
+  for (let attempt = 1; attempt <= state.config.startupRetryAttempts; attempt += 1) {
+    try {
+      await sendToDiscord(baseMessage);
+      registerSuccess();
+      return { ok: true };
+    } catch (error) {
+      lastError = error;
+      registerFailure(error);
+      // Backoff: 1s, 3s, 6s, 12s, ...
+      const delayMs = Math.min(30_000, 1000 * 2 ** (attempt - 1) + Math.floor(Math.random() * 250));
+      await sleep(delayMs);
+    }
+  }
+
+  return { ok: false, reason: lastError?.message || 'unknown' };
+}
+
+function stop() {
+  state.stopped = true;
+  if (state.flushTimer) {
+    clearInterval(state.flushTimer);
+    state.flushTimer = null;
+  }
+}
+
+function getHealth() {
+  return {
+    enabled: state.config.enabled,
+    guildId: state.config.guildId,
+    channelId: state.config.channelId,
+    queueLength: state.queue.length,
+    droppedCount: state.droppedCount,
+    lastSuccessAt: state.lastSuccessAtMs ? toIso(state.lastSuccessAtMs) : null,
+    lastFailureAt: state.lastFailureAtMs ? toIso(state.lastFailureAtMs) : null,
+    consecutiveFailures: state.consecutiveFailures,
+    circuitOpenUntil: state.disabledUntilMs ? toIso(state.disabledUntilMs) : null,
+    level: state.config.level,
+  };
+}
+
+function logEvent(level, event, fields, message) {
+  enqueue({
+    timestamp: toIso(),
+    level: String(level || 'info').toLowerCase(),
+    event: String(event || 'event').trim() || 'event',
+    message: message != null ? String(message) : null,
+    fields: fields && typeof fields === 'object' ? fields : null,
+    correlationId: getCorrelationId(),
+  });
+}
+
+function logError(event, error, fields) {
+  const message = error instanceof Error ? error.message : String(error);
+  const stack = error instanceof Error ? error.stack : null;
+
+  logEvent('error', event, {
+    ...fields,
+    error: message,
+    stack: stack ? String(stack).slice(0, 900) : null,
+  });
+}
+
+module.exports = {
+  buildConfig,
+  flush,
+  getHealth,
+  logError,
+  logEvent,
+  start,
+  stop,
+  validateStartup,
+  __private: {
+    LEVELS,
+    enqueue,
+    formatDiscordMessage,
+    formatEntry,
+    registerFailure,
+    registerSuccess,
+    resolveLogsChannel,
+    sanitizeValue,
+    shouldPost,
+    state,
+  },
+};

--- a/js/services/discordFormat.js
+++ b/js/services/discordFormat.js
@@ -1,0 +1,22 @@
+function formatDiscordTimestamp(iso, options = {}) {
+  const style = String(options.style || 'F').trim() || 'F';
+  const fallback = Object.prototype.hasOwnProperty.call(options, 'fallback')
+    ? options.fallback
+    : 'unknown';
+
+  if (!iso) {
+    return fallback;
+  }
+
+  const timestamp = new Date(iso).getTime();
+  if (!Number.isFinite(timestamp)) {
+    return fallback;
+  }
+
+  return `<t:${Math.floor(timestamp / 1000)}:${style}>`;
+}
+
+module.exports = {
+  formatDiscordTimestamp,
+};
+

--- a/js/services/messageStyle.js
+++ b/js/services/messageStyle.js
@@ -1,0 +1,57 @@
+const { EmbedBuilder } = require('discord.js');
+
+const COLORS = {
+  primary: '#0099ff',
+  info: '#2980b9',
+  success: '#1f8b4c',
+  warning: '#f39c12',
+  danger: '#c0392b',
+  neutral: '#264653',
+};
+
+function buildScriptureFooter(passage) {
+  const translationName = String(passage?.translationName || 'World English Bible').trim();
+  const note = String(passage?.translationNote || 'Public Domain').trim();
+  const noteSuffix = note ? ` (${note})` : '';
+
+  // Keep source attribution consistent across all scripture outputs.
+  return `${translationName}${noteSuffix} \u2022 bible-api.com`;
+}
+
+function buildStandardEmbed(options = {}) {
+  const embed = new EmbedBuilder();
+
+  if (options.title) {
+    embed.setTitle(String(options.title));
+  }
+  if (options.description) {
+    embed.setDescription(String(options.description));
+  }
+
+  embed.setColor(options.color || COLORS.primary);
+  // Consistent timestamps across bot messages are intentional.
+  // If a caller truly needs to omit a timestamp, pass `timestamp: null`.
+  if (options.timestamp === null) {
+    // omit
+  } else if (options.timestamp instanceof Date) {
+    embed.setTimestamp(options.timestamp);
+  } else {
+    embed.setTimestamp(new Date());
+  }
+
+  if (options.footerText) {
+    embed.setFooter({ text: String(options.footerText) });
+  }
+
+  if (Array.isArray(options.fields) && options.fields.length > 0) {
+    embed.addFields(options.fields);
+  }
+
+  return embed;
+}
+
+module.exports = {
+  COLORS,
+  buildScriptureFooter,
+  buildStandardEmbed,
+};

--- a/js/services/planScheduler.js
+++ b/js/services/planScheduler.js
@@ -1,9 +1,12 @@
 const cron = require('node-cron');
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 
 const { logger } = require('../logger.js');
 const { listActivePlans, getPlanById, bumpDayIndex, setPlanStatus } = require('../db/planDB.js');
 const { getReadingForDay, buildReferenceLabel } = require('./planEngine.js');
+const devBotLogs = require('./devBotLogs.js');
+const { generateCorrelationId, runWithCorrelationId } = require('./correlation.js');
+const { buildStandardEmbed, COLORS } = require('./messageStyle.js');
 
 const tasks = new Map();
 
@@ -52,17 +55,15 @@ function formatLocalTimeParts(timezone, date = new Date()) {
 
 function buildGuildPlanSummaryEmbed(plan, localDate, refs) {
   const title = `Reading Plan: ${plan.planType}`;
-  const embed = new EmbedBuilder()
-    .setTitle(title)
-    .setColor('#0099ff')
-    .setTimestamp(new Date())
-    .setDescription(
+  const embed = buildStandardEmbed({
+    title,
+    color: COLORS.primary,
+    description:
       `**Today's reading (${localDate})**\n` +
-        refs.map((ref) => `- ${buildReferenceLabel(ref)}`).join('\n')
-    )
-    .setFooter({
-      text: 'Use the button below to DM yourself today’s reading (with pagination).',
-    });
+      refs.map((ref) => `- ${buildReferenceLabel(ref)}`).join('\n'),
+    footerText: 'Use the button below to DM yourself today’s reading (with pagination).',
+    timestamp: new Date(),
+  });
 
   return embed;
 }
@@ -79,65 +80,91 @@ function buildGuildPlanComponents(planId, dayIndex, localDate) {
 }
 
 async function postPlanTick(client, planId, options = {}) {
-  const plan = await getPlanById(planId);
-  if (!plan || plan.status !== 'active') {
-    return;
-  }
+  const correlationId = generateCorrelationId();
 
-  const localDate = formatLocalDate(plan.timezone);
-  if (plan.startDate && localDate < plan.startDate) {
-    // Respect future-dated plans: don't post until the plan's start date in its timezone.
-    return;
-  }
-  if (plan.lastPostedOn === localDate) {
-    return;
-  }
-
-  const refs = getReadingForDay(plan, plan.dayIndex);
-  if (refs.length === 0) {
-    logger.info(`Plan ${plan.id} has no more readings. Marking stopped.`);
-    await setPlanStatus(plan.id, 'stopped');
-    const task = tasks.get(plan.id);
-    if (task) {
-      try {
-        task.stop();
-      } catch (error) {
-        // ignore
-      }
-      tasks.delete(plan.id);
-    }
-    return;
-  }
-
-  if (plan.ownerType === 'guild') {
-    if (!plan.channelId) {
-      logger.warn(`Guild plan ${plan.id} has no channelId; skipping post.`);
+  await runWithCorrelationId(correlationId, async () => {
+    const plan = await getPlanById(planId);
+    if (!plan || plan.status !== 'active') {
       return;
     }
 
-    const channel = await client.channels.fetch(plan.channelId).catch(() => null);
-    if (!channel || typeof channel.send !== 'function') {
-      logger.warn(`Unable to fetch channel ${plan.channelId} for plan ${plan.id}`);
+    const localDate = formatLocalDate(plan.timezone);
+    if (plan.startDate && localDate < plan.startDate) {
+      // Respect future-dated plans: don't post until the plan's start date in its timezone.
+      return;
+    }
+    if (plan.lastPostedOn === localDate) {
       return;
     }
 
-    const embed = buildGuildPlanSummaryEmbed(plan, localDate, refs);
-    const components = buildGuildPlanComponents(plan.id, plan.dayIndex, localDate);
-
-    const lateSuffix = options.late ? ' (late)' : '';
-    embed.setTitle(`Reading Plan: ${plan.planType}${lateSuffix}`);
-    await channel.send({ embeds: [embed], components });
-  } else {
-    // User plan: DM the full reading (with pagination).
-    const { sendUserPlanReading } = require('./planInteractions.js');
-    await sendUserPlanReading(client, plan, plan.dayIndex, localDate, {
-      targetUserId: plan.ownerId,
-      includeCompletion: true,
+    const tickStartedAt = Date.now();
+    devBotLogs.logEvent('info', 'plan.tick.start', {
+      planId: plan.id,
+      ownerType: plan.ownerType,
+      ownerId: plan.ownerId,
+      dayIndex: plan.dayIndex,
+      localDate,
       late: options.late === true,
     });
-  }
 
-  await bumpDayIndex(plan.id, localDate);
+    const refs = getReadingForDay(plan, plan.dayIndex);
+    if (refs.length === 0) {
+      logger.info(`Plan ${plan.id} has no more readings. Marking stopped.`);
+      await setPlanStatus(plan.id, 'stopped');
+      const task = tasks.get(plan.id);
+      if (task) {
+        try {
+          task.stop();
+        } catch (error) {
+          // ignore
+        }
+        tasks.delete(plan.id);
+      }
+      devBotLogs.logEvent('info', 'plan.tick.stop', {
+        planId: plan.id,
+        localDate,
+        durationMs: Date.now() - tickStartedAt,
+      });
+      return;
+    }
+
+    if (plan.ownerType === 'guild') {
+      if (!plan.channelId) {
+        logger.warn(`Guild plan ${plan.id} has no channelId; skipping post.`);
+        devBotLogs.logEvent('warn', 'plan.tick.skip', { planId: plan.id, reason: 'missing_channelId' });
+        return;
+      }
+
+      const channel = await client.channels.fetch(plan.channelId).catch(() => null);
+      if (!channel || typeof channel.send !== 'function') {
+        logger.warn(`Unable to fetch channel ${plan.channelId} for plan ${plan.id}`);
+        devBotLogs.logEvent('warn', 'plan.tick.skip', { planId: plan.id, reason: 'channel_fetch_failed', channelId: plan.channelId });
+        return;
+      }
+
+      const embed = buildGuildPlanSummaryEmbed(plan, localDate, refs);
+      const components = buildGuildPlanComponents(plan.id, plan.dayIndex, localDate);
+
+      const lateSuffix = options.late ? ' (late)' : '';
+      embed.setTitle(`Reading Plan: ${plan.planType}${lateSuffix}`);
+      await channel.send({ embeds: [embed], components });
+    } else {
+      // User plan: DM the full reading (with pagination).
+      const { sendUserPlanReading } = require('./planInteractions.js');
+      await sendUserPlanReading(client, plan, plan.dayIndex, localDate, {
+        targetUserId: plan.ownerId,
+        includeCompletion: true,
+        late: options.late === true,
+      });
+    }
+
+    await bumpDayIndex(plan.id, localDate);
+    devBotLogs.logEvent('info', 'plan.tick.end', {
+      planId: plan.id,
+      localDate,
+      durationMs: Date.now() - tickStartedAt,
+    });
+  });
 }
 
 function stopAllTasks() {
@@ -167,6 +194,7 @@ async function refreshPlanSchedules(client) {
             await postPlanTick(client, plan.id);
           } catch (error) {
             logger.error(`Plan tick failed for plan ${plan.id}`, error);
+            devBotLogs.logError('plan.tick.error', error, { planId: plan.id });
           }
         },
         {

--- a/js/services/readSessions.js
+++ b/js/services/readSessions.js
@@ -19,6 +19,7 @@ const { fetchPassageForBookChapter } = require('./bibleApiWeb.js');
 const { parseScriptureReference } = require('./scriptureReference.js');
 const { paginateLines } = require('./pagination.js');
 const { buildEmbedTitle, formatPassageLines } = require('./passageFormatter.js');
+const { buildScriptureFooter, COLORS } = require('./messageStyle.js');
 
 const CUSTOM_ID_PREFIX = 'rd';
 const DEFAULT_TTL_MS = 25 * 60 * 1000;
@@ -137,7 +138,9 @@ async function loadPassagePages(session, options = {}) {
   });
 
   const lines = formatPassageLines(passage);
-  const pages = paginateLines(lines, { maxChars: 3400 });
+  // DM "page-turner" mode: keep pages smaller for readability and faster scrolling.
+  // This intentionally roughly halves the previous size to double page count.
+  const pages = paginateLines(lines, { maxChars: 1700 });
 
   session.cache.set(cacheKey, { passage, pages });
   session.passage = passage;
@@ -161,14 +164,12 @@ function buildEmbed(session) {
   const total = session.pages.length;
   const pageIndex = Math.min(Math.max(session.pageIndex, 0), total - 1);
 
-  const translationName = String(passage?.translationName || 'World English Bible').trim();
-  const note = String(passage?.translationNote || '').trim();
-  const footerBase = `${translationName}${note ? ` • ${note}` : ''} • Source: bible-api.com`;
+  const footerBase = buildScriptureFooter(passage);
 
   const embed = new EmbedBuilder()
     .setTitle(title)
     .setDescription(session.pages[pageIndex])
-    .setColor('#0099ff')
+    .setColor(COLORS.primary)
     .setFooter({
       text: `${footerBase} • Page ${pageIndex + 1}/${total}`,
     })

--- a/js/services/versionInfo.js
+++ b/js/services/versionInfo.js
@@ -1,0 +1,188 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const DEFAULT_MANIFEST_PATH = path.join(__dirname, '..', '..', 'build', 'version.json');
+const DEFAULT_PACKAGE_JSON_PATH = path.join(__dirname, '..', '..', 'package.json');
+
+let cachedPackageVersion = null;
+let cachedGitSha = null;
+
+function readJsonFile(filePath) {
+  if (!filePath) {
+    return null;
+  }
+
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeIsoTimestamp(value) {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    return null;
+  }
+
+  // Allow build/deploy scripts to provide either ISO timestamps or epoch seconds.
+  if (/^\d+$/.test(raw)) {
+    const epochSeconds = Number(raw);
+    if (!Number.isFinite(epochSeconds) || epochSeconds <= 0) {
+      return null;
+    }
+
+    return new Date(epochSeconds * 1000).toISOString();
+  }
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+function resolveRuntimeEnvironment(environment = process.env) {
+  return String(
+    environment.DEPLOY_ENVIRONMENT || environment.APP_ENV || environment.NODE_ENV || ''
+  )
+    .trim()
+    .toLowerCase();
+}
+
+function resolvePackageVersion(options = {}) {
+  if (cachedPackageVersion !== null && !options.packageJsonPath) {
+    return cachedPackageVersion;
+  }
+
+  const packageJsonPath = options.packageJsonPath || DEFAULT_PACKAGE_JSON_PATH;
+  const packageJson = readJsonFile(packageJsonPath);
+  const version = String(packageJson?.version || '').trim() || null;
+
+  if (!options.packageJsonPath) {
+    cachedPackageVersion = version;
+  }
+
+  return version;
+}
+
+function resolveGitSha(options = {}) {
+  if (cachedGitSha !== null && !options.disableCache) {
+    return cachedGitSha;
+  }
+
+  const environment = options.environment || process.env;
+
+  const environmentSha =
+    environment.GIT_SHA ||
+    environment.COMMIT_SHA ||
+    environment.GITHUB_SHA ||
+    '';
+  if (environmentSha) {
+    cachedGitSha = String(environmentSha).slice(0, 12);
+    return cachedGitSha;
+  }
+
+  try {
+    const sha = execSync('git rev-parse --short HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim();
+    cachedGitSha = sha || 'unknown';
+  } catch {
+    cachedGitSha = 'unknown';
+  }
+
+  return cachedGitSha;
+}
+
+function resolveManifest(options = {}) {
+  const manifestPath = options.manifestPath || DEFAULT_MANIFEST_PATH;
+  const manifest = readJsonFile(manifestPath);
+  if (!manifest || typeof manifest !== 'object') {
+    return null;
+  }
+
+  const tag = String(manifest.tag || manifest.releaseTag || '').trim() || null;
+  const sha = String(manifest.sha || '').trim() || null;
+  const builtAt = normalizeIsoTimestamp(manifest.builtAt);
+
+  return {
+    tag,
+    sha,
+    builtAt,
+    raw: manifest,
+  };
+}
+
+function resolveReleaseTag(environment = process.env, manifest) {
+  const fromEnv =
+    String(environment.RELEASE_TAG || environment.APP_VERSION || '').trim() ||
+    String(environment.GITHUB_REF_NAME || '').trim();
+
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  if (manifest?.tag) {
+    return manifest.tag;
+  }
+
+  return null;
+}
+
+function resolveDeployedAt(environment = process.env) {
+  const deployedAt =
+    normalizeIsoTimestamp(environment.DEPLOYED_AT) ||
+    normalizeIsoTimestamp(environment.DEPLOY_TIME) ||
+    null;
+  return deployedAt;
+}
+
+function getVersionInfo(options = {}) {
+  const environment = options.environment || process.env;
+  const runtimeEnvironment = resolveRuntimeEnvironment(environment);
+  const manifest = resolveManifest(options);
+  const packageVersion = resolvePackageVersion(options);
+
+  const releaseTag = resolveReleaseTag(environment, manifest);
+  const gitSha = resolveGitSha({ ...options, environment });
+  const builtAt = manifest?.builtAt || null;
+  const deployedAt = resolveDeployedAt(environment);
+
+  return {
+    runtimeEnvironment,
+    packageVersion,
+    releaseTag,
+    gitSha,
+    builtAt,
+    deployedAt,
+    manifest,
+  };
+}
+
+module.exports = {
+  getVersionInfo,
+  __private: {
+    DEFAULT_MANIFEST_PATH,
+    DEFAULT_PACKAGE_JSON_PATH,
+    normalizeIsoTimestamp,
+    readJsonFile,
+    resolveDeployedAt,
+    resolveGitSha,
+    resolveManifest,
+    resolvePackageVersion,
+    resolveReleaseTag,
+    resolveRuntimeEnvironment,
+  },
+};

--- a/js/verseSender.js
+++ b/js/verseSender.js
@@ -1,8 +1,8 @@
-const { EmbedBuilder } = require('discord.js');
 const { logger } = require('./logger.js');
 const { getRandomBibleVerse } = require('./services/bibleApi');
 const { addVerseSent } = require('./db/statsDB.js');
 const { getTranslationLabel } = require('./constants/translations.js');
+const { buildStandardEmbed, COLORS } = require('./services/messageStyle.js');
 
 async function sendDailyVerse(client, userOrId, passage, options = {}) {
   const resolvedUserId =
@@ -36,16 +36,17 @@ async function sendDailyVerse(client, userOrId, passage, options = {}) {
     `Sending verse to ${user.username} (${user.id}) ${verseReference} [${translationLabel}]`
   );
 
-  const embed = new EmbedBuilder()
-    .setTitle('Daily Bible Verse')
-    .setDescription(verseText)
-    .setColor('#0099ff')
-    .addFields(
-      { name: 'Reference', value: verseReference },
-      { name: 'Translation', value: translationLabel },
-    )
-    .setFooter({ text: 'Sent by Daily Bible Verse Bot' })
-    .setThumbnail(client.user.displayAvatarURL());
+  const title = passage === 'random' ? 'Random Bible Verse' : 'Daily Bible Verse';
+  const embed = buildStandardEmbed({
+    title,
+    description: verseText,
+    color: COLORS.primary,
+    fields: [
+      { name: 'Reference', value: verseReference, inline: false },
+      { name: 'Translation', value: translationLabel, inline: true },
+    ],
+    footerText: 'Daily Bible Verse Bot',
+  }).setThumbnail(client.user.displayAvatarURL());
 
   try {
     await user.send({ embeds: [embed] });

--- a/test/devBotLogs.test.js
+++ b/test/devBotLogs.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const devBotLogs = require('../js/services/devBotLogs.js');
+
+function createFakeClient(channel) {
+  return {
+    channels: {
+      async fetch() {
+        return channel;
+      },
+    },
+    guilds: {
+      cache: new Map(),
+      async fetch() {
+        return null;
+      },
+    },
+  };
+}
+
+test('devBotLogs batches multiple entries into a single Discord message', async () => {
+  const sent = [];
+  const channel = {
+    async send(payload) {
+      sent.push(payload);
+      return { id: String(sent.length) };
+    },
+  };
+
+  devBotLogs.stop();
+  devBotLogs.start(createFakeClient(channel), {
+    config: {
+      enabled: true,
+      channelId: '123',
+      guildId: 'g',
+      level: 'info',
+      flushIntervalMs: 10_000,
+      maxBatchItems: 10,
+      maxQueueItems: 100,
+      maxMessageChars: 1900,
+      coalesceWindowMs: 10_000,
+      startupRetryAttempts: 1,
+    },
+  });
+
+  devBotLogs.logEvent('info', 'test.one', { a: 1 }, 'hello');
+  devBotLogs.logEvent('info', 'test.two', { b: 2 }, 'world');
+
+  await devBotLogs.flush();
+
+  assert.equal(sent.length, 1);
+  assert.ok(String(sent[0].content || '').includes('test.one'));
+  assert.ok(String(sent[0].content || '').includes('test.two'));
+  assert.ok(String(sent[0].content || '').startsWith('```log'));
+});
+
+test('devBotLogs opens a circuit breaker after repeated send failures', async () => {
+  const channel = {
+    async send() {
+      throw new Error('no perms');
+    },
+  };
+
+  devBotLogs.stop();
+  devBotLogs.start(createFakeClient(channel), {
+    config: {
+      enabled: true,
+      channelId: '123',
+      guildId: 'g',
+      level: 'info',
+      flushIntervalMs: 10_000,
+      maxBatchItems: 5,
+      maxQueueItems: 100,
+      coalesceWindowMs: 10_000,
+      startupRetryAttempts: 1,
+    },
+  });
+
+  devBotLogs.logEvent('warn', 'test.fail', null, 'a');
+  await devBotLogs.flush();
+  devBotLogs.logEvent('warn', 'test.fail', null, 'b');
+  await devBotLogs.flush();
+  devBotLogs.logEvent('warn', 'test.fail', null, 'c');
+  await devBotLogs.flush();
+
+  const health = devBotLogs.getHealth();
+  assert.ok(health.consecutiveFailures >= 3);
+  assert.ok(health.circuitOpenUntil, 'expected circuitOpenUntil to be set');
+});
+

--- a/test/readSessionsPaging.test.js
+++ b/test/readSessionsPaging.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createReadSession } = require('../js/services/readSessions.js');
+const { formatPassageLines } = require('../js/services/passageFormatter.js');
+
+function buildFakePassage(verseCount = 60) {
+  const verses = [];
+  for (let i = 1; i <= verseCount; i += 1) {
+    verses.push({
+      book_id: 'JHN',
+      book_name: 'John',
+      chapter: 3,
+      verse: i,
+      text: `Verse ${i} ${'lorem ipsum '.repeat(12)}`.trim(),
+    });
+  }
+
+  return {
+    reference: 'John 3',
+    translation_id: 'web',
+    translation_name: 'World English Bible',
+    translation_note: 'Public Domain',
+    verses,
+    text: verses.map((v) => v.text).join(' '),
+  };
+}
+
+test('/read paging uses smaller pages and never splits verse lines', async () => {
+  const fakePassage = buildFakePassage(70);
+
+  const fetchImpl = async () =>
+    new Response(JSON.stringify(fakePassage), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  const session = await createReadSession({
+    userId: '123',
+    reference: 'JHN 3',
+    fetchImpl,
+  });
+
+  assert.ok(Array.isArray(session.pages));
+  assert.ok(session.pages.length >= 2, 'expected multiple pages for long chapter');
+
+  // Page size target is ~1700 chars; never exceed it.
+  for (const page of session.pages) {
+    assert.ok(page.length <= 1700, `page exceeded max chars: ${page.length}`);
+  }
+
+  // Ensure verse lines appear intact in exactly one page.
+  const expectedLines = formatPassageLines({
+    verses: fakePassage.verses.map((verse) => ({
+      bookId: verse.book_id,
+      bookName: verse.book_name,
+      chapter: verse.chapter,
+      verse: verse.verse,
+      text: verse.text,
+    })),
+  });
+
+  for (const line of expectedLines) {
+    const hits = session.pages.filter((page) => page.split('\n').includes(line)).length;
+    assert.equal(hits, 1, `expected verse line to appear once: ${line.slice(0, 30)}...`);
+  }
+});
+

--- a/test/versionInfo.test.js
+++ b/test/versionInfo.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { getVersionInfo, __private } = require('../js/services/versionInfo.js');
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dbvb-version-'));
+}
+
+test('getVersionInfo prefers env RELEASE_TAG over manifest tag', () => {
+  const dir = createTempDir();
+  const manifestPath = path.join(dir, 'version.json');
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify({ tag: 'v1.2.3', sha: 'abc', builtAt: '2024-01-01T00:00:00Z' })
+  );
+
+  const packageJsonPath = path.join(dir, 'package.json');
+  fs.writeFileSync(packageJsonPath, JSON.stringify({ name: 'x', version: '9.9.9' }));
+
+  const info = getVersionInfo({
+    environment: {
+      RELEASE_TAG: 'canary-deadbeef',
+      GIT_SHA: 'deadbeefcafebabe',
+      DEPLOY_ENVIRONMENT: 'canary',
+      DEPLOYED_AT: '2025-02-01T12:00:00Z',
+    },
+    manifestPath,
+    packageJsonPath,
+    disableCache: true,
+  });
+
+  assert.equal(info.releaseTag, 'canary-deadbeef');
+  assert.equal(info.packageVersion, '9.9.9');
+  assert.equal(info.gitSha, 'deadbeefcafe');
+  assert.equal(info.builtAt, '2024-01-01T00:00:00.000Z');
+  assert.equal(info.deployedAt, '2025-02-01T12:00:00.000Z');
+  assert.equal(info.runtimeEnvironment, 'canary');
+});
+
+test('normalizeIsoTimestamp converts epoch seconds to ISO', () => {
+  assert.equal(__private.normalizeIsoTimestamp('0'), null);
+  assert.equal(__private.normalizeIsoTimestamp('1700000000'), new Date(1700000000 * 1000).toISOString());
+});


### PR DESCRIPTION
Promotes canary to production after successful canary deploy.

Changes included:
- Dev Discord #bot-logs sink with batching + circuit breaker + correlation IDs.
- Status channel version accuracy via build/version.json + deploy-time env vars.
- /read DM paging reduced to ~1700 chars per page (no mid-verse splits).
- Shared embed/footer helpers for consistent message styling.

Verification:
- Canary deploy succeeded: https://github.com/michaelpa-dev/Daily-Bible-Verse-Bot/actions/runs/22021093798
- Canary instance is running and bot logs show status message upserts without dev log sink failures.

Copilot Merge Gate Checklist:
- [ ] Copilot review requested / automatic review confirmed enabled
- [ ] Copilot review comments received (or explicit completion state)
- [ ] Every Copilot comment fixed OR replied-to with justification
- [ ] CI is green (tests/lint)
- [ ] Deployment-impact changes documented (if any)