### PR TITLE
fix(ci): canary prune step jq quoting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,19 +226,27 @@ jobs:
 
           echo "Pruning old canary prereleases (tag prefix canary-), keeping newest 5..."
 
-          releases="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate)"
+          releases="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate 2>/dev/null || true)"
+          if [ -z "${releases}" ]; then
+            echo "Warning: unable to list releases (API error or rate limit). Skipping prune."
+            exit 0
+          fi
+
           to_delete="$(printf '%s' "${releases}" | jq -r '
             [
               .[]
               | select(.prerelease == true)
-              | select(.tag_name | startswith(\"canary-\"))
+              | select(.tag_name | startswith("canary-"))
               | { tag: .tag_name, created: .created_at }
             ]
             | sort_by(.created)
             | reverse
             | .[5:]
             | .[].tag
-          ')"
+          ' 2>/dev/null)" || {
+            echo "Warning: jq failed while computing releases to delete. Skipping prune."
+            exit 0
+          }
 
           if [ -z "${to_delete}" ] || [ "${to_delete}" = "null" ]; then
             echo "No old canary releases to delete."
@@ -253,7 +261,7 @@ jobs:
               continue
             fi
             echo "Deleting canary release ${tag}..."
-            gh release delete "${tag}" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag
+            gh release delete "${tag}" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag || echo "Warning: failed to delete ${tag} (continuing)"
           done <<< "${to_delete}"
 
       - name: Dispatch production deploy (release-only)


### PR DESCRIPTION
## What Changed
- Fixed the jq filter used by the canary prerelease retention step (it was using invalid \" quoting, causing build failures).
- Made the prune step best-effort so retention failures never block artifact creation/deploys.

## Why
The Build and Release workflow on `canary` is currently failing during the prune step, which prevents release asset creation and breaks SSM-based deploys.

## Verification
- CI should pass (lint/format/tests)
- Build workflow should no longer fail in the prune step

## Copilot Review Gate Checklist
- [ ] Copilot review requested / automatic review confirmed enabled
- [ ] Copilot review comments received (or explicit completion state)
- [ ] Every Copilot comment fixed OR replied-to with justification
- [ ] CI is green (tests/lint/format)
- [ ] Deployment-impact changes documented
