### PR TITLE
fix(ci): remove SSM describe-instance-information dependency

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -105,37 +105,6 @@ jobs:
           aws ec2 wait instance-running --region "${AWS_REGION}" --instance-ids "${INSTANCE_ID}"
           aws ec2 wait instance-status-ok --region "${AWS_REGION}" --instance-ids "${INSTANCE_ID}"
 
-      - name: Wait for SSM agent (managed instance online)
-        shell: bash
-        env:
-          INSTANCE_ID: ${{ steps.resolve.outputs.instance_id }}
-        run: |
-          set -euo pipefail
-
-          echo "Waiting for SSM PingStatus=Online on ${INSTANCE_ID}..."
-          for attempt in $(seq 1 40); do
-            ping_status="$(aws ssm describe-instance-information \
-              --region "${AWS_REGION}" \
-              --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
-              --query "InstanceInformationList[0].PingStatus" \
-              --output text 2>/dev/null || true)"
-
-            if [ "${ping_status}" = "Online" ]; then
-              echo "SSM PingStatus: Online"
-              exit 0
-            fi
-
-            echo "SSM not online yet (attempt ${attempt}/40). PingStatus=${ping_status:-unknown}. Waiting 10s..."
-            sleep 10
-          done
-
-          echo "SSM did not report Online for ${INSTANCE_ID} within timeout." >&2
-          aws ssm describe-instance-information \
-            --region "${AWS_REGION}" \
-            --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
-            --output json || true
-          exit 1
-
       - name: Sync BOT_TOKEN to SSM Parameter Store (SecureString)
         shell: bash
         env:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -224,37 +224,6 @@ jobs:
           echo "download_url=${download_url}" >> "$GITHUB_OUTPUT"
           echo "download_kind=${download_kind}" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for SSM agent (managed instance online)
-        shell: bash
-        env:
-          INSTANCE_ID: ${{ steps.resolve.outputs.instance_id }}
-        run: |
-          set -euo pipefail
-
-          echo "Waiting for SSM PingStatus=Online on ${INSTANCE_ID}..."
-          for attempt in $(seq 1 40); do
-            ping_status="$(aws ssm describe-instance-information \
-              --region "${AWS_REGION}" \
-              --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
-              --query "InstanceInformationList[0].PingStatus" \
-              --output text 2>/dev/null || true)"
-
-            if [ "${ping_status}" = "Online" ]; then
-              echo "SSM PingStatus: Online"
-              exit 0
-            fi
-
-            echo "SSM not online yet (attempt ${attempt}/40). PingStatus=${ping_status:-unknown}. Waiting 10s..."
-            sleep 10
-          done
-
-          echo "SSM did not report Online for ${INSTANCE_ID} within timeout." >&2
-          aws ssm describe-instance-information \
-            --region "${AWS_REGION}" \
-            --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
-            --output json || true
-          exit 1
-
       - name: Deploy production via SSM RunCommand (GitHub Release artifact)
         id: ssm
         shell: bash


### PR DESCRIPTION
## What Changed
- Removed the "Wait for SSM agent (managed instance online)" step from canary + prod deploy workflows.

## Why
The GitHub Actions OIDC role does not currently have `ssm:DescribeInstanceInformation`, which caused canary deploys to fail before even sending the SSM deploy command.

We still wait for the SSM RunCommand invocation to appear and reach a terminal status (Success/Failed/etc), so deploys remain reliable without needing additional IAM permissions.

## Verification
- CI should pass.
- Canary deploy should proceed past the SSM wait and reach the send-command/polling steps.

## Copilot Review Gate Checklist
- [ ] Copilot review requested / automatic review confirmed enabled
- [ ] Copilot review comments received (or explicit completion state)
- [ ] Every Copilot comment fixed OR replied-to with justification
- [ ] CI is green (tests/lint/format)
- [ ] Deployment-impact changes documented
