### PR TITLE
fix(ci): canary prune uses published_at

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          CURRENT_TAG: ${{ steps.meta.outputs.release_tag }}
         run: |
           set -euo pipefail
 
@@ -237,9 +238,9 @@ jobs:
               .[]
               | select(.prerelease == true)
               | select(.tag_name | startswith("canary-"))
-              | { tag: .tag_name, created: .created_at }
+              | { tag: .tag_name, sortKey: (.published_at // .created_at // .updated_at) }
             ]
-            | sort_by(.created)
+            | sort_by(.sortKey)
             | reverse
             | .[5:]
             | .[].tag
@@ -247,6 +248,12 @@ jobs:
             echo "Warning: jq failed while computing releases to delete. Skipping prune."
             exit 0
           }
+
+          # Safety guard: never delete the release we just created for this workflow run,
+          # even if sorting/ordering is unexpected.
+          if [ -n "${to_delete}" ] && [ "${to_delete}" != "null" ]; then
+            to_delete="$(printf '%s\n' "${to_delete}" | grep -v "^${CURRENT_TAG}$" || true)"
+          fi
 
           if [ -z "${to_delete}" ] || [ "${to_delete}" = "null" ]; then
             echo "No old canary releases to delete."


### PR DESCRIPTION
## What Changed
- Fixed canary prerelease retention sorting to use `published_at` (with fallbacks) instead of `created_at`.
- Added a safety guard so we never delete the release tag created by the current build run.

## Why
GitHub Releases for this repo show a constant `created_at` for canary prereleases, which caused the prune step to delete the brand-new canary release tag and break subsequent canary deploys.

## Verification
- CI should pass.
- Canary Build and Release should keep the newly-created `canary-<sha>` tag.

## Copilot Review Gate Checklist
- [ ] Copilot review requested / automatic review confirmed enabled
- [ ] Copilot review comments received (or explicit completion state)
- [ ] Every Copilot comment fixed OR replied-to with justification
- [ ] CI is green (tests/lint/format)
- [ ] Deployment-impact changes documented
