### PR TITLE
Fix #47: align package version metadata with release line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daily-bible-verse-bot",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daily-bible-verse-bot",
-      "version": "0.5.0",
+      "version": "0.5.3",
       "dependencies": {
         "axios": "^1.13.5",
         "discord.js": "^14.25.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daily-bible-verse-bot",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "private": true,
   "main": "js/bot.js",
   "engines": {


### PR DESCRIPTION
Closes #47\n\nSummary:\n- Bump package metadata from 0.5.0 to 0.5.3 in package.json/package-lock.json so local metadata is consistent with current patch line after release automation.\n\nScope:\n- Minimal low-risk metadata patch only; no runtime logic or workflow behavior changes.\n\nTest Plan:\n- npm run lint\n- npm test\n- Verified package.json and package-lock.json top-level version now read 0.5.3\n